### PR TITLE
コンパイルエラーを解消

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ futures = "0.3.31"
 async-trait = "0.1.88"
 
 # 音声処理
-rodio = { version = "0.21.1", features = ["symphonia"] }
-symphonia = { version = "0.5.4", features = ["all-codecs", "flac", "mp3", "ogg", "wav"] }
+rodio = { version = "0.19", features = ["mp3", "flac", "wav", "vorbis"] }
+symphonia = { version = "0.5", features = ["mp3", "flac", "wav", "ogg"] }
 cpal = "0.16.0"
 rustfft = "6.4.0"
 

--- a/src/audio/decoder/mod.rs
+++ b/src/audio/decoder/mod.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use symphonia::core::audio::{AudioBufferRef};
+use symphonia::core::audio::AudioBufferRef;
 use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
 use symphonia::core::errors::Error as SymphoniaError;
 use symphonia::core::formats::{FormatOptions, FormatReader, Track};
@@ -62,7 +62,7 @@ impl UniversalDecoder {
             .format(&hint, mss, &FormatOptions::default(), &MetadataOptions::default())
             .map_err(|e| AudioError::Streaming(format!("Failed to probe format: {}", e)))?;
 
-        let mut format_reader = probed.format;
+        let format_reader = probed.format;
 
         // Find the best audio track
         let track = format_reader
@@ -152,16 +152,20 @@ impl UniversalDecoder {
         let decoded = self.decoder.decode(&packet)
             .map_err(|e| AudioError::Streaming(format!("Failed to decode packet: {}", e)))?;
 
-        // Convert to f32 samples
-        self.convert_samples(&decoded, output)
+        // Convert to f32 samples - split the mutable borrowing
+        Self::convert_samples_to_buffer(decoded, &mut self.sample_buffer, output)
     }
 
-    /// Convert audio buffer to f32 samples
-    fn convert_samples(&mut self, audio_buf: &AudioBufferRef, output: &mut [f32]) -> Result<usize, AudioError> {
+    /// Convert audio buffer to f32 samples (static method to avoid borrowing conflicts)
+    fn convert_samples_to_buffer(
+        audio_buf: AudioBufferRef<'_>, 
+        sample_buffer: &mut Option<symphonia::core::audio::SampleBuffer<f32>>,
+        output: &mut [f32]
+    ) -> Result<usize, AudioError> {
         // Create or reuse sample buffer
-        if self.sample_buffer.is_none() || 
-           self.sample_buffer.as_ref().unwrap().capacity() < audio_buf.frames() {
-            self.sample_buffer = Some(
+        if sample_buffer.is_none() || 
+           sample_buffer.as_ref().unwrap().capacity() < audio_buf.frames() {
+            *sample_buffer = Some(
                 symphonia::core::audio::SampleBuffer::<f32>::new(
                     audio_buf.frames() as u64,
                     *audio_buf.spec(),
@@ -169,12 +173,12 @@ impl UniversalDecoder {
             );
         }
 
-        let sample_buffer = self.sample_buffer.as_mut().unwrap();
+        let buffer = sample_buffer.as_mut().unwrap();
         
-        // Copy and convert samples - fix the reference issue
-        sample_buffer.copy_interleaved_ref(audio_buf.clone());
+        // Copy and convert samples
+        buffer.copy_interleaved_ref(audio_buf);
 
-        let samples = sample_buffer.samples();
+        let samples = buffer.samples();
         let copy_len = samples.len().min(output.len());
         
         output[..copy_len].copy_from_slice(&samples[..copy_len]);

--- a/src/audio/engine.rs
+++ b/src/audio/engine.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use parking_lot::RwLock;
-use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink, Source};
+use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -75,7 +75,7 @@ pub struct AudioEngine {
     /// Command sender for communicating with the audio thread
     command_sender: mpsc::UnboundedSender<AudioCommand>,
     /// Handle to the audio processing thread
-    _audio_thread: tokio::task::JoinHandle<()>,
+    _audio_thread: std::thread::JoinHandle<()>,
     /// Shared status information
     status: Arc<RwLock<AudioEngineStatus>>,
     /// Track information cache
@@ -118,21 +118,30 @@ impl AudioEngine {
 
         let tracks = Arc::new(RwLock::new(HashMap::new()));
 
-        // Spawn the audio processing thread
+        // Clone for worker thread
         let worker_status = Arc::clone(&status);
         let worker_tracks = Arc::clone(&tracks);
 
-        let audio_thread = tokio::spawn(async move {
-            let worker = AudioEngineWorker::new(worker_status, worker_tracks, command_receiver).await;
+        // Spawn the audio processing thread on a dedicated thread pool
+        let audio_thread = std::thread::spawn(move || {
+            // Create a simple blocking runtime for audio operations
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to create audio runtime");
             
-            match worker {
-                Ok(mut worker) => {
-                    worker.run().await;
+            rt.block_on(async move {
+                let worker = AudioEngineWorker::new(worker_status, worker_tracks, command_receiver).await;
+                
+                match worker {
+                    Ok(mut worker) => {
+                        worker.run().await;
+                    }
+                    Err(e) => {
+                        error!("Failed to initialize audio worker: {}", e);
+                    }
                 }
-                Err(e) => {
-                    error!("Failed to initialize audio worker: {}", e);
-                }
-            }
+            });
         });
 
         debug!("Audio engine initialized successfully");
@@ -419,10 +428,12 @@ impl AudioEngineWorker {
         let file = std::fs::File::open(&track_info.path)
             .map_err(|e| AudioError::Streaming(format!("File open error: {}", e)))?;
 
-        let source = Decoder::new(file)
+        // Use BufReader for better performance
+        let buf_reader = std::io::BufReader::new(file);
+        let source = Decoder::new(buf_reader)
             .map_err(|e| AudioError::Streaming(format!("Decoder initialization failed: {}", e)))?;
 
-        // Create new sink
+        // Create new sink using the stored stream handle
         let sink = Sink::try_new(&self.stream_handle)
             .map_err(|e| AudioError::Device(format!("Failed to create audio sink: {}", e)))?;
 
@@ -519,6 +530,18 @@ impl PlaybackStatus for AudioEngine {
 
     fn duration(&self) -> Option<Duration> {
         self.status.read().duration
+    }
+
+    fn is_playing(&self) -> bool {
+        matches!(self.state(), PlaybackState::Playing)
+    }
+
+    fn is_paused(&self) -> bool {
+        matches!(self.state(), PlaybackState::Paused)
+    }
+
+    fn is_stopped(&self) -> bool {
+        matches!(self.state(), PlaybackState::Stopped)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,10 @@
 // Prevent console window in addition to Slint window in Windows release builds when, e.g., starting the app via file manager. Ignored on other platforms.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::error::Error;
+
 use sonic_flow::{Result, SonicFlow};
-use tracing::{erorr, info, warn};
+use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 // slint::include_modules!();


### PR DESCRIPTION
## 追加修正

- 可変参照の2重参照を解決
- rodio APIを安定板に変更し、APIの使い方を調整
- tokio spawnのエラーを解消
- エントリポイント内のtracing::errorの使用のため、std::error::Errorをimport