### PR TITLE
feat(audio): implement Symphonia-based audio decoder

### DIFF
--- a/crates/sonic-core/src/audio/analysis.rs
+++ b/crates/sonic-core/src/audio/analysis.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides real-time FFT processing for the visualizer system.
 
-use rustfft::{num_complex::Complex, FftPlanner};
+use rustfft::{FftPlanner, num_complex::Complex};
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 

--- a/crates/sonic-core/src/audio/decoder/mod.rs
+++ b/crates/sonic-core/src/audio/decoder/mod.rs
@@ -1,0 +1,65 @@
+//! Audio decoder trait and supporting types.
+//!
+//! Provides a unified interface for decoding audio from various container
+//! formats (MP3, FLAC, WAV, OGG, AAC, OPUS) backed by Symphonia.
+
+pub mod registry;
+mod symphonia;
+
+pub use symphonia::SymphoniaDecoder;
+
+use std::time::Duration;
+
+use crate::audio::traits::AudioFormatType;
+use crate::error::AudioError;
+
+/// A single packet of decoded, interleaved f32 audio samples.
+#[derive(Debug, Clone)]
+pub struct AudioBuffer {
+    /// Interleaved samples in channel order (e.g. [L, R, L, R, ...] for stereo).
+    pub samples: Vec<f32>,
+    /// Sample rate in Hz.
+    pub sample_rate: u32,
+    /// Channel count.
+    pub channels: u16,
+}
+
+/// Detailed information about an audio stream returned by a decoder.
+#[derive(Debug, Clone)]
+pub struct AudioFormatInfo {
+    /// Sample rate in Hz (e.g. 44100, 48000, 192000).
+    pub sample_rate: u32,
+    /// Number of channels.
+    pub channels: u16,
+    /// Bit depth per sample, if reported by the container (e.g. 16, 24, 32).
+    pub bit_depth: Option<u32>,
+    /// Container/format type inferred from the file extension.
+    pub format_type: AudioFormatType,
+    /// Total duration, if known before full decode.
+    pub duration: Option<Duration>,
+    /// Human-readable codec name (e.g. "FLAC", "MP3").
+    pub codec_name: String,
+}
+
+/// Unified interface for audio decoders.
+///
+/// Implementations are expected to be `Send` so they can be driven from
+/// a dedicated audio or blocking thread.
+pub trait AudioDecoder: Send {
+    /// Decode the next packet of audio samples.
+    ///
+    /// Returns `Ok(None)` when the stream is fully consumed.
+    fn decode_next(&mut self) -> Result<Option<AudioBuffer>, AudioError>;
+
+    /// Seek to the requested playback position.
+    ///
+    /// Returns the actual position seeked to, which may differ from the
+    /// requested position due to keyframe alignment.
+    fn seek(&mut self, position: Duration) -> Result<Duration, AudioError>;
+
+    /// Total duration of the stream, if known from container metadata.
+    fn duration(&self) -> Option<Duration>;
+
+    /// Format and codec information for the stream.
+    fn format_info(&self) -> AudioFormatInfo;
+}

--- a/crates/sonic-core/src/audio/decoder/registry.rs
+++ b/crates/sonic-core/src/audio/decoder/registry.rs
@@ -1,0 +1,54 @@
+//! Decoder registry — selects the appropriate decoder for a given file path.
+//!
+//! Currently all supported formats are handled by [`SymphoniaDecoder`], so
+//! this module acts as a thin factory. It exists as an extension point for
+//! future format-specific overrides.
+
+use std::path::Path;
+
+use crate::audio::traits::AudioFormatType;
+use crate::error::AudioError;
+
+use super::{AudioDecoder, SymphoniaDecoder};
+
+/// Open an audio file and return a boxed [`AudioDecoder`].
+///
+/// The format is determined from the file extension. Returns
+/// [`AudioError::UnsupportedFormat`] for unknown extensions before attempting
+/// to open the file.
+pub fn open(path: &Path) -> Result<Box<dyn AudioDecoder>, AudioError> {
+    let ext =
+        path.extension()
+            .and_then(|e| e.to_str())
+            .ok_or_else(|| AudioError::UnsupportedFormat {
+                format: "no extension".into(),
+            })?;
+
+    let format_type = AudioFormatType::from_extension(ext);
+    if !format_type.is_supported() {
+        return Err(AudioError::UnsupportedFormat {
+            format: ext.to_string(),
+        });
+    }
+
+    let decoder = SymphoniaDecoder::open(path)?;
+    Ok(Box::new(decoder))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn unsupported_extension_rejected_before_io() {
+        let result = open(&PathBuf::from("music.xyz"));
+        assert!(matches!(result, Err(AudioError::UnsupportedFormat { .. })));
+    }
+
+    #[test]
+    fn missing_extension_rejected() {
+        let result = open(&PathBuf::from("music_no_ext"));
+        assert!(matches!(result, Err(AudioError::UnsupportedFormat { .. })));
+    }
+}

--- a/crates/sonic-core/src/audio/decoder/symphonia.rs
+++ b/crates/sonic-core/src/audio/decoder/symphonia.rs
@@ -1,0 +1,307 @@
+//! Symphonia-backed audio decoder.
+//!
+//! Supports MP3, FLAC, WAV, OGG Vorbis, AAC, OPUS and any other format
+//! enabled by the `symphonia` crate's feature flags.
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::path::Path;
+use std::time::Duration;
+
+use rodio::Source;
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::{CODEC_TYPE_NULL, Decoder as SymphDecoder, DecoderOptions};
+use symphonia::core::errors::Error as SymphError;
+use symphonia::core::formats::{FormatOptions, FormatReader, SeekMode, SeekTo};
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+use symphonia::core::units::{Time, TimeBase};
+
+use crate::audio::traits::AudioFormatType;
+use crate::error::AudioError;
+
+use super::{AudioBuffer, AudioDecoder, AudioFormatInfo};
+
+/// Symphonia-based decoder that implements both [`AudioDecoder`] and
+/// [`rodio::Source`], allowing it to be pushed directly into a `rodio::Sink`.
+pub struct SymphoniaDecoder {
+    format_reader: Box<dyn FormatReader>,
+    decoder: Box<dyn SymphDecoder>,
+    /// ID of the selected audio track within the container.
+    track_id: u32,
+    sample_rate: u32,
+    channels: u16,
+    duration: Option<Duration>,
+    /// Stored to convert timestamp units back to wall-clock time after seeking.
+    time_base: Option<TimeBase>,
+    format_info: AudioFormatInfo,
+    /// Decoded samples waiting to be consumed by the [`Iterator`] impl.
+    sample_buf: VecDeque<f32>,
+    exhausted: bool,
+}
+
+impl SymphoniaDecoder {
+    /// Open an audio file and prepare the decoder.
+    ///
+    /// The container format is probed automatically. The first non-null audio
+    /// track is selected for playback.
+    pub fn open(path: &Path) -> Result<Self, AudioError> {
+        let file = File::open(path).map_err(|e| {
+            AudioError::Streaming(format!("Failed to open '{}': {e}", path.display()))
+        })?;
+
+        let mut hint = Hint::new();
+        if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+            hint.with_extension(ext);
+        }
+
+        let mss = MediaSourceStream::new(Box::new(file), Default::default());
+
+        let probed = symphonia::default::get_probe()
+            .format(
+                &hint,
+                mss,
+                &FormatOptions::default(),
+                &MetadataOptions::default(),
+            )
+            .map_err(|e| {
+                AudioError::Decode(format!("Format probe failed for '{}': {e}", path.display()))
+            })?;
+
+        let format_reader = probed.format;
+
+        // Select the first non-null audio track.
+        let track = format_reader
+            .tracks()
+            .iter()
+            .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+            .ok_or_else(|| AudioError::Decode("No supported audio track found".into()))?;
+
+        let track_id = track.id;
+        let sample_rate = track.codec_params.sample_rate.unwrap_or(44100);
+        let channels = track
+            .codec_params
+            .channels
+            .map(|c| c.count() as u16)
+            .unwrap_or(2);
+        let bit_depth = track.codec_params.bits_per_sample;
+        let time_base = track.codec_params.time_base;
+
+        let duration = time_base.zip(track.codec_params.n_frames).map(|(tb, n)| {
+            let t = tb.calc_time(n);
+            Duration::from_secs_f64(t.seconds as f64 + t.frac)
+        });
+
+        let format_type = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(AudioFormatType::from_extension)
+            .unwrap_or(AudioFormatType::Unknown("unknown".into()));
+
+        let codec_name = format_type.codec_name().to_string();
+
+        let format_info = AudioFormatInfo {
+            sample_rate,
+            channels,
+            bit_depth,
+            format_type,
+            duration,
+            codec_name,
+        };
+
+        let decoder = symphonia::default::get_codecs()
+            .make(&track.codec_params, &DecoderOptions::default())
+            .map_err(|e| AudioError::Decode(format!("Failed to create codec decoder: {e}")))?;
+
+        Ok(Self {
+            format_reader,
+            decoder,
+            track_id,
+            sample_rate,
+            channels,
+            duration,
+            time_base,
+            format_info,
+            sample_buf: VecDeque::new(),
+            exhausted: false,
+        })
+    }
+
+    /// Decode the next packet from the format reader into `self.sample_buf`.
+    ///
+    /// Returns `true` if new samples were pushed, `false` when the stream is
+    /// exhausted or an unrecoverable error occurs.
+    fn fill_buffer(&mut self) -> bool {
+        loop {
+            let packet = match self.format_reader.next_packet() {
+                Ok(p) => p,
+                // Any IO error (including EOF) means the stream is done.
+                Err(SymphError::IoError(_)) => {
+                    self.exhausted = true;
+                    return false;
+                }
+                // Decoder state must be reset after a discontinuity.
+                Err(SymphError::ResetRequired) => {
+                    self.decoder.reset();
+                    continue;
+                }
+                Err(_) => {
+                    self.exhausted = true;
+                    return false;
+                }
+            };
+
+            // Skip packets belonging to other tracks (e.g. subtitle or video).
+            if packet.track_id() != self.track_id {
+                continue;
+            }
+
+            match self.decoder.decode(&packet) {
+                Ok(decoded) => {
+                    let spec = *decoded.spec();
+                    let capacity = decoded.capacity() as u64;
+                    let mut buf = SampleBuffer::<f32>::new(capacity, spec);
+                    buf.copy_interleaved_ref(decoded);
+                    self.sample_buf.extend(buf.samples().iter().copied());
+                    return true;
+                }
+                // Damaged packets can be skipped without stopping playback.
+                Err(SymphError::DecodeError(_)) => continue,
+                Err(_) => {
+                    self.exhausted = true;
+                    return false;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AudioDecoder trait
+// ---------------------------------------------------------------------------
+
+impl AudioDecoder for SymphoniaDecoder {
+    fn decode_next(&mut self) -> Result<Option<AudioBuffer>, AudioError> {
+        if self.exhausted && self.sample_buf.is_empty() {
+            return Ok(None);
+        }
+
+        if self.sample_buf.is_empty() && !self.fill_buffer() {
+            return Ok(None);
+        }
+
+        // Drain the entire internal buffer as one logical packet.
+        let samples: Vec<f32> = self.sample_buf.drain(..).collect();
+        Ok(Some(AudioBuffer {
+            samples,
+            sample_rate: self.sample_rate,
+            channels: self.channels,
+        }))
+    }
+
+    fn seek(&mut self, position: Duration) -> Result<Duration, AudioError> {
+        let secs = position.as_secs_f64();
+        let time = Time {
+            seconds: secs as u64,
+            frac: secs.fract(),
+        };
+
+        let seeked = self
+            .format_reader
+            .seek(
+                SeekMode::Accurate,
+                SeekTo::Time {
+                    time,
+                    track_id: Some(self.track_id),
+                },
+            )
+            .map_err(|e| AudioError::Streaming(format!("Seek failed: {e}")))?;
+
+        // Reset decoder state so the next packet is treated as a fresh start.
+        self.decoder.reset();
+        self.sample_buf.clear();
+        self.exhausted = false;
+
+        // Convert the actual timestamp back to wall-clock time.
+        let actual = self.time_base.map_or(position, |tb| {
+            let t = tb.calc_time(seeked.actual_ts);
+            Duration::from_secs_f64(t.seconds as f64 + t.frac)
+        });
+
+        Ok(actual)
+    }
+
+    fn duration(&self) -> Option<Duration> {
+        self.duration
+    }
+
+    fn format_info(&self) -> AudioFormatInfo {
+        self.format_info.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// rodio::Source — allows the decoder to be pushed directly into a rodio Sink
+// ---------------------------------------------------------------------------
+
+impl Iterator for SymphoniaDecoder {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<f32> {
+        // Fast path: buffered samples from the last decoded packet.
+        if let Some(s) = self.sample_buf.pop_front() {
+            return Some(s);
+        }
+        if self.exhausted || !self.fill_buffer() {
+            return None;
+        }
+        self.sample_buf.pop_front()
+    }
+}
+
+impl Source for SymphoniaDecoder {
+    fn current_frame_len(&self) -> Option<usize> {
+        // Returning None lets rodio pull samples one at a time from next().
+        None
+    }
+
+    fn channels(&self) -> u16 {
+        self.channels
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        self.duration
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn open_nonexistent_file_returns_error() {
+        let result = SymphoniaDecoder::open(&PathBuf::from("nonexistent.mp3"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn open_unsupported_path_returns_streaming_error() {
+        // Cannot test with a real file in unit tests, but we can verify that
+        // the constructor correctly rejects missing files.
+        let result = SymphoniaDecoder::open(&PathBuf::from("missing.flac"));
+        assert!(
+            matches!(result, Err(AudioError::Streaming(_))),
+            "expected Streaming error for missing file"
+        );
+    }
+}

--- a/crates/sonic-core/src/audio/metadata.rs
+++ b/crates/sonic-core/src/audio/metadata.rs
@@ -11,8 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::AudioError;
 
 /// Comprehensive audio track metadata
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TrackMetadata {
     // Basic information
     pub title: Option<String>,
@@ -228,17 +227,18 @@ impl MetadataExtractor {
         // Extract artwork from PICTURE blocks
         for block in tag.blocks() {
             if let metaflac::block::BlockType::Picture = block.block_type()
-                && let metaflac::block::Block::Picture(picture) = block {
-                    metadata.artwork = Some(ArtworkInfo {
-                        mime_type: picture.mime_type.clone(),
-                        description: Some(picture.description.clone()),
-                        artwork_type: Self::convert_flac_picture_type(picture.picture_type),
-                        width: Some(picture.width),
-                        height: Some(picture.height),
-                        data: picture.data.clone(),
-                    });
-                    break; // Use first picture found
-                }
+                && let metaflac::block::Block::Picture(picture) = block
+            {
+                metadata.artwork = Some(ArtworkInfo {
+                    mime_type: picture.mime_type.clone(),
+                    description: Some(picture.description.clone()),
+                    artwork_type: Self::convert_flac_picture_type(picture.picture_type),
+                    width: Some(picture.width),
+                    height: Some(picture.height),
+                    data: picture.data.clone(),
+                });
+                break; // Use first picture found
+            }
         }
 
         // Get file information
@@ -330,23 +330,24 @@ impl MetadataExtractor {
 
         // Extract metadata from Symphonia
         if let Some(symphonia_metadata) = probed.metadata.get()
-            && let Some(current) = symphonia_metadata.current() {
-                for tag in current.tags() {
-                    match tag.key.as_str() {
-                        "TITLE" => metadata.title = Some(tag.value.to_string()),
-                        "ARTIST" => metadata.artist = Some(tag.value.to_string()),
-                        "ALBUM" => metadata.album = Some(tag.value.to_string()),
-                        "DATE" => metadata.year = tag.value.to_string().parse().ok(),
-                        "TRACK" => metadata.track_number = tag.value.to_string().parse().ok(),
-                        "GENRE" => metadata.genre = Some(tag.value.to_string()),
-                        _ => {
-                            metadata
-                                .custom_tags
-                                .insert(tag.key.clone(), tag.value.to_string());
-                        }
+            && let Some(current) = symphonia_metadata.current()
+        {
+            for tag in current.tags() {
+                match tag.key.as_str() {
+                    "TITLE" => metadata.title = Some(tag.value.to_string()),
+                    "ARTIST" => metadata.artist = Some(tag.value.to_string()),
+                    "ALBUM" => metadata.album = Some(tag.value.to_string()),
+                    "DATE" => metadata.year = tag.value.to_string().parse().ok(),
+                    "TRACK" => metadata.track_number = tag.value.to_string().parse().ok(),
+                    "GENRE" => metadata.genre = Some(tag.value.to_string()),
+                    _ => {
+                        metadata
+                            .custom_tags
+                            .insert(tag.key.clone(), tag.value.to_string());
                     }
                 }
             }
+        }
 
         Ok(metadata)
     }
@@ -398,7 +399,6 @@ impl MetadataExtractor {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/sonic-core/src/audio/mod.rs
+++ b/crates/sonic-core/src/audio/mod.rs
@@ -1,10 +1,12 @@
 //! Audio playback, decoding, metadata, and spectrum analysis.
 
 pub mod analysis;
+pub mod decoder;
 pub mod metadata;
-pub mod player_manager;
 pub mod player;
+pub mod player_manager;
 pub mod traits;
 
+pub use decoder::{AudioBuffer, AudioDecoder, AudioFormatInfo, SymphoniaDecoder};
 pub use player_manager::{PlayerManager, PlayerStatus};
 pub use traits::{AudioFormat, AudioFormatType};

--- a/crates/sonic-core/src/audio/player.rs
+++ b/crates/sonic-core/src/audio/player.rs
@@ -1,108 +1,138 @@
-//! Rodio-based audio player.
+//! Rodio-backed audio player.
+//!
+//! Wraps a `rodio::Sink` and drives it with a [`SymphoniaDecoder`] source.
+//! Seeking is implemented by re-opening the file, seeking the decoder, and
+//! replacing the sink's source.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tokio::time::sleep;
 
-use rodio::{Decoder, OutputStream, Sink, Source};
+use rodio::{OutputStream, Sink};
 use tracing::info;
 
-use crate::audio::traits::AudioFormatType;
+use crate::audio::decoder::{AudioDecoder, AudioFormatInfo, SymphoniaDecoder};
 use crate::error::AudioError;
 
-/// Audio player backed by rodio.
+/// Audio player backed by a `rodio::Sink`.
+///
+/// Not `Clone` — intended to be owned by the audio thread inside
+/// [`super::player_manager::PlayerManager`].
 pub struct Player {
-    /// Audio output stream
+    /// Kept alive to maintain the audio output stream.
     _stream: OutputStream,
-    /// Stream handle for creating sinks
     stream_handle: rodio::OutputStreamHandle,
-    /// Current audio sink
     sink: Option<Sink>,
+    /// Path of the currently loaded file, required for seek re-opening.
+    current_path: Option<PathBuf>,
+    /// Volume applied to every new sink (0.0 – 1.0).
+    volume: f32,
 }
 
+// OutputStreamHandle is Send but OutputStream is not — we own both exclusively.
 unsafe impl Send for Player {}
 unsafe impl Sync for Player {}
 
 impl Player {
-    /// Create a new simple player
+    /// Create a new player connected to the default audio output device.
     pub fn new() -> Result<Self, AudioError> {
         let (stream, stream_handle) = OutputStream::try_default()
-            .map_err(|e| AudioError::Device(format!("Failed to initialize audio output: {}", e)))?;
+            .map_err(|e| AudioError::Device(format!("Failed to initialise audio output: {e}")))?;
 
         Ok(Self {
             _stream: stream,
             stream_handle,
             sink: None,
+            current_path: None,
+            volume: 0.8,
         })
     }
 
-    /// Load and play an audio file.
-    pub async fn play_file(&mut self, path: &Path) -> Result<(), AudioError> {
+    /// Load and immediately begin playing an audio file.
+    ///
+    /// Stops any current playback before opening the new file.
+    /// Returns [`AudioFormatInfo`] with the stream's sample rate, channel
+    /// count, bit depth, and duration.
+    pub fn play_file(&mut self, path: &Path) -> Result<AudioFormatInfo, AudioError> {
         info!("Loading audio file: {}", path.display());
 
-        if !path.exists() {
-            return Err(AudioError::Streaming(format!(
-                "File not found: {}",
-                path.display()
-            )));
+        // Stop existing sink before creating a new one.
+        if let Some(old) = self.sink.take() {
+            old.stop();
         }
 
-        let extension = path
-            .extension()
-            .and_then(|s| s.to_str())
-            .ok_or_else(|| AudioError::UnsupportedFormat {
-                format: "unknown".to_string(),
-            })?;
+        let decoder = SymphoniaDecoder::open(path)?;
+        let info = decoder.format_info();
 
-        if !AudioFormatType::from_extension(extension).is_supported() {
-            return Err(AudioError::UnsupportedFormat {
-                format: extension.to_string(),
-            });
-        }
-
-        let file = std::fs::File::open(path).map_err(|e| {
-            AudioError::Streaming(format!("Failed to open file {}: {}", path.display(), e))
-        })?;
-
-        let source = Decoder::new(std::io::BufReader::new(file))
-            .map_err(|e| AudioError::Streaming(format!("Failed to decode file: {}", e)))?;
-
-        let sample_rate = source.sample_rate();
-        let channels = source.channels();
         info!(
-            "Audio file info - Sample rate: {} Hz, Channels: {}",
-            sample_rate, channels
+            "Opened: {} Hz, {} ch, {:?} bit, codec={}, duration={:?}",
+            info.sample_rate, info.channels, info.bit_depth, info.codec_name, info.duration,
         );
 
-        // Create sink
-        let sink = Sink::try_new(&self.stream_handle).map_err(|e| {
-            AudioError::Device(format!("Failed to create audio sink: {}", e))
-        })?;
-
-        // Set volume
-        sink.set_volume(0.8);
-
-        // Add source to sink and play
-        sink.append(source);
+        let sink = Sink::try_new(&self.stream_handle)
+            .map_err(|e| AudioError::Device(format!("Failed to create audio sink: {e}")))?;
+        sink.set_volume(self.volume);
+        sink.append(decoder);
         sink.play();
 
-        // Store sink
         self.sink = Some(sink);
+        self.current_path = Some(path.to_owned());
 
-        info!("MP3 playback started");
-        Ok(())
+        Ok(info)
     }
 
-    /// Stop playback
+    /// Seek to `position` within the currently loaded file.
+    ///
+    /// Implemented by re-opening the decoder, seeking it, then swapping the
+    /// sink's source. Preserves the current pause/play state.
+    ///
+    /// Returns the actual position seeked to (may differ from requested due to
+    /// keyframe alignment).
+    pub fn seek(&mut self, position: Duration) -> Result<Duration, AudioError> {
+        let path = self
+            .current_path
+            .clone()
+            .ok_or_else(|| AudioError::InvalidState {
+                from: "no_file_loaded".into(),
+                to: "seek".into(),
+            })?;
+
+        let was_paused = self.sink.as_ref().map(|s| s.is_paused()).unwrap_or(false);
+
+        // Open a fresh decoder and seek it to the requested position.
+        let mut decoder = SymphoniaDecoder::open(&path)?;
+        let actual = decoder.seek(position)?;
+
+        // Replace the sink with a new one using the seeked decoder.
+        if let Some(old) = self.sink.take() {
+            old.stop();
+        }
+
+        let sink = Sink::try_new(&self.stream_handle).map_err(|e| {
+            AudioError::Device(format!("Failed to create audio sink after seek: {e}"))
+        })?;
+        sink.set_volume(self.volume);
+        sink.append(decoder);
+        // Restore pause state — Sink starts playing by default after append.
+        if was_paused {
+            sink.pause();
+        }
+
+        self.sink = Some(sink);
+
+        info!("Seeked to {:?} (requested {:?})", actual, position);
+        Ok(actual)
+    }
+
+    /// Stop playback and release the current source.
     pub fn stop(&mut self) {
-        if let Some(sink) = &self.sink {
+        if let Some(sink) = self.sink.take() {
             sink.stop();
             info!("Playback stopped");
         }
-        self.sink = None;
+        self.current_path = None;
     }
 
-    /// Pause playback
+    /// Pause playback. No-op when already paused or no track is loaded.
     pub fn pause(&mut self) {
         if let Some(sink) = &self.sink {
             sink.pause();
@@ -110,7 +140,7 @@ impl Player {
         }
     }
 
-    /// Resume playback
+    /// Resume playback. No-op when already playing or no track is loaded.
     pub fn resume(&mut self) {
         if let Some(sink) = &self.sink {
             sink.play();
@@ -118,28 +148,30 @@ impl Player {
         }
     }
 
-    /// Check if currently playing
+    /// Returns `true` when audio is actively playing (not paused, not empty).
     pub fn is_playing(&self) -> bool {
         self.sink
             .as_ref()
-            .map(|sink| !sink.is_paused() && !sink.empty())
+            .map(|s| !s.is_paused() && !s.empty())
             .unwrap_or(false)
     }
 
-    /// Set volume (0.0 - 1.0)
+    /// Returns `true` when the sink is paused (but may still have a source).
+    pub fn is_paused(&self) -> bool {
+        self.sink.as_ref().map(|s| s.is_paused()).unwrap_or(false)
+    }
+
+    /// Set output volume. Clamped to [0.0, 1.0]. Persists across seeks.
     pub fn set_volume(&mut self, volume: f32) {
+        self.volume = volume.clamp(0.0, 1.0);
         if let Some(sink) = &self.sink {
-            sink.set_volume(volume.clamp(0.0, 1.0));
+            sink.set_volume(self.volume);
         }
     }
 
-    /// Wait for playback to finish
-    pub async fn wait_for_finish(&self) {
-        if let Some(sink) = &self.sink {
-            while !sink.empty() {
-                sleep(Duration::from_millis(100)).await;
-            }
-        }
+    /// Returns the path of the currently loaded file, if any.
+    pub fn current_path(&self) -> Option<&Path> {
+        self.current_path.as_deref()
     }
 }
 
@@ -154,32 +186,28 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    #[tokio::test]
-    async fn test_player_creation() {
-        // Test creating a simple player
-        let result = Player::new();
-        match result {
-            Ok(_player) => {
-                // Player creation successful
-                assert!(true);
-            }
-            Err(e) => {
-                // Audio system might not be available in test environment
-                eprintln!("Audio system not available in test: {}", e);
-            }
+    #[test]
+    fn player_creation() {
+        // Audio device may not be available in CI — treat as a soft failure.
+        match Player::new() {
+            Ok(_) => {}
+            Err(e) => eprintln!("Audio device unavailable in test environment: {e}"),
         }
     }
 
-    #[tokio::test]
-    async fn test_mp3_file_validation() {
+    #[test]
+    fn play_nonexistent_file_returns_error() {
         if let Ok(mut player) = Player::new() {
-            // Test with non-existent file
-            let result = player.play_file(&PathBuf::from("nonexistent.mp3")).await;
+            let result = player.play_file(&PathBuf::from("nonexistent.mp3"));
             assert!(result.is_err());
+        }
+    }
 
-            // Test with wrong extension
-            let result = player.play_file(&PathBuf::from("test.txt")).await;
-            assert!(result.is_err());
+    #[test]
+    fn seek_without_loaded_file_returns_error() {
+        if let Ok(mut player) = Player::new() {
+            let result = player.seek(Duration::from_secs(10));
+            assert!(matches!(result, Err(AudioError::InvalidState { .. })));
         }
     }
 }

--- a/crates/sonic-core/src/audio/player_manager.rs
+++ b/crates/sonic-core/src/audio/player_manager.rs
@@ -1,71 +1,66 @@
-//! Thread-safe audio player manager
+//! Thread-safe audio player manager.
 //!
-//! This module provides a thread-safe wrapper around audio playback functionality
-//! that works with Slint's single-threaded UI model.
+//! Bridges Slint's single-threaded UI model with the audio [`Player`] that
+//! runs on a dedicated tokio task. Commands are sent over an unbounded channel
+//! and responses are returned via one-shot channels.
 
-use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, warn};
 
-use crate::audio::traits::{AudioFormat, AudioFormatType};
-use crate::error::AudioError;
+use crate::audio::decoder::AudioFormatInfo;
 use crate::audio::player::Player;
+use crate::audio::traits::AudioFormat;
+use crate::error::AudioError;
 
-/// Commands for the audio player manager
+// ---------------------------------------------------------------------------
+// Command / Status types
+// ---------------------------------------------------------------------------
+
+/// Commands sent to the player task.
 #[derive(Debug)]
 pub enum PlayerCommand {
-    /// Load and play a file
     LoadAndPlay {
         path: PathBuf,
         response: oneshot::Sender<Result<(), AudioError>>,
     },
-    /// Start playback
     Play {
         response: oneshot::Sender<Result<(), AudioError>>,
     },
-    /// Pause playback
     Pause {
         response: oneshot::Sender<Result<(), AudioError>>,
     },
-    /// Stop playback
     Stop {
         response: oneshot::Sender<Result<(), AudioError>>,
     },
-    /// Set volume (0.0 - 1.0)
     SetVolume {
         volume: f32,
         response: oneshot::Sender<Result<(), AudioError>>,
     },
-    /// Seek to position
     Seek {
         position: Duration,
-        response: oneshot::Sender<Result<(), AudioError>>,
+        response: oneshot::Sender<Result<Duration, AudioError>>,
     },
-    /// Get current player status
     GetStatus {
         response: oneshot::Sender<PlayerStatus>,
     },
-    /// Shutdown the player manager
     Shutdown,
 }
 
-/// Current status of the audio player
+/// Snapshot of the audio player's current state.
 #[derive(Debug, Clone)]
 pub struct PlayerStatus {
-    /// Whether audio is currently playing
     pub is_playing: bool,
-    /// Whether audio is paused
     pub is_paused: bool,
-    /// Current volume (0.0 - 1.0)
     pub volume: f32,
-    /// Currently loaded track path
     pub current_track: Option<PathBuf>,
-    /// Current playback position
+    /// Current playback position (approximate, based on elapsed wall time).
     pub position: Duration,
-    /// Total duration (if known)
+    /// Total duration of the loaded track, if known.
     pub duration: Option<Duration>,
-    /// Audio format information
+    /// Audio format information for the loaded track.
     pub format: Option<AudioFormat>,
 }
 
@@ -83,23 +78,23 @@ impl Default for PlayerStatus {
     }
 }
 
-/// Thread-safe audio player manager
+// ---------------------------------------------------------------------------
+// PlayerManager
+// ---------------------------------------------------------------------------
+
+/// Thread-safe handle to the audio player task.
 pub struct PlayerManager {
-    /// Command sender for communication with the player thread
     command_tx: mpsc::UnboundedSender<PlayerCommand>,
-    /// Join handle for the player thread
     _player_thread: tokio::task::JoinHandle<()>,
 }
 
 impl PlayerManager {
-    /// Create a new player manager
+    /// Spawn the audio player task and return a handle.
     pub fn new() -> Result<Self, AudioError> {
-        info!("Initializing player manager");
+        info!("Initialising player manager");
 
         let (command_tx, command_rx) = mpsc::unbounded_channel();
-
-        // Spawn the player thread
-        let player_thread = tokio::spawn(Self::player_thread_main(command_rx));
+        let player_thread = tokio::spawn(Self::player_task(command_rx));
 
         Ok(Self {
             command_tx,
@@ -107,234 +102,246 @@ impl PlayerManager {
         })
     }
 
-    /// Load and play an audio file
+    // ------------------------------------------------------------------
+    // Public async API
+    // ------------------------------------------------------------------
+
     pub async fn load_and_play(&self, path: PathBuf) -> Result<(), AudioError> {
-        let (response_tx, response_rx) = oneshot::channel();
-        
-        self.command_tx
-            .send(PlayerCommand::LoadAndPlay { path, response: response_tx })
-            .map_err(|_| AudioError::InvalidState {
-                from: "player_manager".to_string(),
-                to: "load_and_play".to_string(),
-            })?;
-
-        response_rx.await.map_err(|_| AudioError::InvalidState {
-            from: "player_manager".to_string(),
-            to: "load_and_play_response".to_string(),
-        })?
+        self.send_recv(|tx| PlayerCommand::LoadAndPlay { path, response: tx })
+            .await
     }
 
-    /// Start playback
     pub async fn play(&self) -> Result<(), AudioError> {
-        let (response_tx, response_rx) = oneshot::channel();
-        
-        self.command_tx
-            .send(PlayerCommand::Play { response: response_tx })
-            .map_err(|_| AudioError::InvalidState {
-                from: "player_manager".to_string(),
-                to: "play".to_string(),
-            })?;
-
-        response_rx.await.map_err(|_| AudioError::InvalidState {
-            from: "player_manager".to_string(),
-            to: "play_response".to_string(),
-        })?
+        self.send_recv(|tx| PlayerCommand::Play { response: tx })
+            .await
     }
 
-    /// Pause playback
     pub async fn pause(&self) -> Result<(), AudioError> {
-        let (response_tx, response_rx) = oneshot::channel();
-        
-        self.command_tx
-            .send(PlayerCommand::Pause { response: response_tx })
-            .map_err(|_| AudioError::InvalidState {
-                from: "player_manager".to_string(),
-                to: "pause".to_string(),
-            })?;
-
-        response_rx.await.map_err(|_| AudioError::InvalidState {
-            from: "player_manager".to_string(),
-            to: "pause_response".to_string(),
-        })?
+        self.send_recv(|tx| PlayerCommand::Pause { response: tx })
+            .await
     }
 
-    /// Stop playback
     pub async fn stop(&self) -> Result<(), AudioError> {
-        let (response_tx, response_rx) = oneshot::channel();
-        
-        self.command_tx
-            .send(PlayerCommand::Stop { response: response_tx })
-            .map_err(|_| AudioError::InvalidState {
-                from: "player_manager".to_string(),
-                to: "stop".to_string(),
-            })?;
-
-        response_rx.await.map_err(|_| AudioError::InvalidState {
-            from: "player_manager".to_string(),
-            to: "stop_response".to_string(),
-        })?
+        self.send_recv(|tx| PlayerCommand::Stop { response: tx })
+            .await
     }
 
-    /// Set volume
     pub async fn set_volume(&self, volume: f32) -> Result<(), AudioError> {
-        let (response_tx, response_rx) = oneshot::channel();
-        
-        self.command_tx
-            .send(PlayerCommand::SetVolume { volume, response: response_tx })
-            .map_err(|_| AudioError::InvalidState {
-                from: "player_manager".to_string(),
-                to: "set_volume".to_string(),
-            })?;
-
-        response_rx.await.map_err(|_| AudioError::InvalidState {
-            from: "player_manager".to_string(),
-            to: "set_volume_response".to_string(),
-        })?
+        self.send_recv(|tx| PlayerCommand::SetVolume {
+            volume,
+            response: tx,
+        })
+        .await
     }
 
-    /// Get current player status
+    /// Seek to the given position. Returns the actual position seeked to.
+    pub async fn seek(&self, position: Duration) -> Result<Duration, AudioError> {
+        let (tx, rx) = oneshot::channel();
+        self.command_tx
+            .send(PlayerCommand::Seek {
+                position,
+                response: tx,
+            })
+            .map_err(|_| self.dead_err("seek"))?;
+        rx.await.map_err(|_| self.dead_err("seek_response"))?
+    }
+
     pub async fn get_status(&self) -> PlayerStatus {
-        let (response_tx, response_rx) = oneshot::channel();
-        
+        let (tx, rx) = oneshot::channel();
         if self
             .command_tx
-            .send(PlayerCommand::GetStatus { response: response_tx })
+            .send(PlayerCommand::GetStatus { response: tx })
             .is_err()
         {
-            warn!("Failed to send status request");
+            warn!("Player task has stopped; returning default status");
             return PlayerStatus::default();
         }
-
-        response_rx.await.unwrap_or_default()
+        rx.await.unwrap_or_default()
     }
 
-    /// Shutdown the player manager
     pub async fn shutdown(&self) {
-        if self.command_tx.send(PlayerCommand::Shutdown).is_err() {
-            warn!("Failed to send shutdown command");
+        let _ = self.command_tx.send(PlayerCommand::Shutdown);
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    fn dead_err(&self, op: &str) -> AudioError {
+        AudioError::InvalidState {
+            from: "player_manager".into(),
+            to: op.into(),
         }
     }
 
-    /// Main loop for the player thread
-    async fn player_thread_main(mut command_rx: mpsc::UnboundedReceiver<PlayerCommand>) {
-        info!("Player thread started");
-        
+    /// Send a command that has a `Result<T, AudioError>` response channel.
+    async fn send_recv<F, T>(&self, make_cmd: F) -> Result<T, AudioError>
+    where
+        F: FnOnce(oneshot::Sender<Result<T, AudioError>>) -> PlayerCommand,
+    {
+        let (tx, rx) = oneshot::channel();
+        self.command_tx
+            .send(make_cmd(tx))
+            .map_err(|_| self.dead_err("send"))?;
+        rx.await.map_err(|_| self.dead_err("recv"))?
+    }
+
+    // ------------------------------------------------------------------
+    // Player task (runs on a tokio thread)
+    // ------------------------------------------------------------------
+
+    async fn player_task(mut rx: mpsc::UnboundedReceiver<PlayerCommand>) {
+        info!("Player task started");
+
+        // All mutable state lives here — no locking required.
         let mut player: Option<Player> = None;
         let mut current_track: Option<PathBuf> = None;
-        let mut current_volume = 0.8f32;
+        let mut current_volume = 0.8_f32;
+        let mut current_format: Option<AudioFormatInfo> = None;
 
-        while let Some(command) = command_rx.recv().await {
-            match command {
+        // Position tracking: position = seek_base + elapsed since play_start.
+        let mut seek_base = Duration::ZERO;
+        let mut play_start: Option<Instant> = None;
+
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
                 PlayerCommand::LoadAndPlay { path, response } => {
-                    debug!("Loading and playing: {}", path.display());
-                    
-                    let result = match Self::load_file(&mut player, &path).await {
-                        Ok(_) => {
+                    debug!("LoadAndPlay: {}", path.display());
+
+                    let result = Self::ensure_player(&mut player).and_then(|p| p.play_file(&path));
+
+                    let result = match result {
+                        Ok(info) => {
                             current_track = Some(path.clone());
+                            current_format = Some(info);
+                            seek_base = Duration::ZERO;
+                            play_start = Some(Instant::now());
                             if let Some(p) = &mut player {
                                 p.set_volume(current_volume);
                             }
                             Ok(())
                         }
                         Err(e) => {
-                            error!("Failed to load file: {}", e);
+                            error!("Failed to load '{}': {e}", path.display());
                             Err(e)
                         }
                     };
-                    
+
                     let _ = response.send(result);
                 }
 
                 PlayerCommand::Play { response } => {
-                    debug!("Play command received");
-                    
                     let result = if let Some(p) = &mut player {
                         p.resume();
+                        play_start = Some(Instant::now());
                         Ok(())
                     } else {
                         Err(AudioError::InvalidState {
-                            from: "no_player".to_string(),
-                            to: "play".to_string(),
+                            from: "idle".into(),
+                            to: "play".into(),
                         })
                     };
-                    
                     let _ = response.send(result);
                 }
 
                 PlayerCommand::Pause { response } => {
-                    debug!("Pause command received");
-                    
                     let result = if let Some(p) = &mut player {
+                        // Snapshot position before pausing.
+                        if let Some(start) = play_start.take() {
+                            seek_base += start.elapsed();
+                        }
                         p.pause();
                         Ok(())
                     } else {
                         Err(AudioError::InvalidState {
-                            from: "no_player".to_string(),
-                            to: "pause".to_string(),
+                            from: "idle".into(),
+                            to: "pause".into(),
                         })
                     };
-                    
                     let _ = response.send(result);
                 }
 
                 PlayerCommand::Stop { response } => {
-                    debug!("Stop command received");
-                    
-                    let result = if let Some(p) = &mut player {
+                    if let Some(p) = &mut player {
                         p.stop();
-                        Ok(())
-                    } else {
-                        Err(AudioError::InvalidState {
-                            from: "no_player".to_string(),
-                            to: "stop".to_string(),
-                        })
-                    };
-                    
-                    let _ = response.send(result);
+                    }
+                    current_track = None;
+                    current_format = None;
+                    seek_base = Duration::ZERO;
+                    play_start = None;
+                    let _ = response.send(Ok(()));
                 }
 
                 PlayerCommand::SetVolume { volume, response } => {
-                    debug!("Set volume to: {:.2}", volume);
-                    
                     current_volume = volume.clamp(0.0, 1.0);
-                    
-                    let result = if let Some(p) = &mut player {
+                    if let Some(p) = &mut player {
                         p.set_volume(current_volume);
-                        Ok(())
-                    } else {
-                        Ok(()) // Store volume for when player is created
-                    };
-                    
-                    let _ = response.send(result);
+                    }
+                    let _ = response.send(Ok(()));
                 }
 
                 PlayerCommand::Seek { position, response } => {
-                    debug!("Seek to: {:?}", position);
-                    
-                    // TODO: Implement seeking when Player supports it
-                    let result = Err(AudioError::UnsupportedFormat {
-                        format: "seek_not_implemented".to_string(),
-                    });
-                    
+                    let result = if let Some(p) = &mut player {
+                        match p.seek(position) {
+                            Ok(actual) => {
+                                seek_base = actual;
+                                play_start = if p.is_paused() {
+                                    None
+                                } else {
+                                    Some(Instant::now())
+                                };
+                                Ok(actual)
+                            }
+                            Err(e) => Err(e),
+                        }
+                    } else {
+                        Err(AudioError::InvalidState {
+                            from: "idle".into(),
+                            to: "seek".into(),
+                        })
+                    };
                     let _ = response.send(result);
                 }
 
                 PlayerCommand::GetStatus { response } => {
-                    let status = PlayerStatus {
-                        is_playing: player.as_ref().map(|p| p.is_playing()).unwrap_or(false),
-                        is_paused: player.as_ref().map(|p| !p.is_playing()).unwrap_or(true),
+                    let is_playing = player.as_ref().map(|p| p.is_playing()).unwrap_or(false);
+                    let is_paused = player.as_ref().map(|p| p.is_paused()).unwrap_or(false);
+
+                    // Compute approximate playback position from wall time.
+                    let position = if is_playing {
+                        if let Some(start) = play_start {
+                            seek_base + start.elapsed()
+                        } else {
+                            seek_base
+                        }
+                    } else {
+                        seek_base
+                    };
+
+                    // Clamp to known duration to avoid overshooting.
+                    let duration = current_format.as_ref().and_then(|f| f.duration);
+                    let position = duration.map_or(position, |d| position.min(d));
+
+                    let format = current_format.as_ref().map(|f| AudioFormat {
+                        sample_rate: f.sample_rate,
+                        channels: f.channels,
+                        bit_depth: f.bit_depth.unwrap_or(16) as u16,
+                        format_type: f.format_type.clone(),
+                    });
+
+                    let _ = response.send(PlayerStatus {
+                        is_playing,
+                        is_paused,
                         volume: current_volume,
                         current_track: current_track.clone(),
-                        position: Duration::ZERO, // TODO: Get actual position
-                        duration: None, // TODO: Get actual duration
-                        format: None, // TODO: Get actual format
-                    };
-                    
-                    let _ = response.send(status);
+                        position,
+                        duration,
+                        format,
+                    });
                 }
 
                 PlayerCommand::Shutdown => {
-                    info!("Player thread shutting down");
+                    info!("Player task shutting down");
                     if let Some(p) = &mut player {
                         p.stop();
                     }
@@ -343,51 +350,20 @@ impl PlayerManager {
             }
         }
 
-        info!("Player thread ended");
+        info!("Player task ended");
     }
 
-    /// Load a file into the player
-    async fn load_file(player: &mut Option<Player>, path: &Path) -> Result<(), AudioError> {
-        // Validate file exists and is supported
-        if !path.exists() {
-            return Err(AudioError::Streaming(format!(
-                "File not found: {}",
-                path.display()
-            )));
-        }
-
-        // Check file extension
-        let extension = path
-            .extension()
-            .and_then(|s| s.to_str())
-            .ok_or_else(|| AudioError::UnsupportedFormat {
-                format: "no_extension".to_string(),
-            })?;
-
-        let format_type = AudioFormatType::from_extension(extension);
-        if !format_type.is_supported() {
-            return Err(AudioError::UnsupportedFormat {
-                format: extension.to_string(),
-            });
-        }
-
-        // Initialize player if needed
+    /// Initialise the player lazily — creates it on first use.
+    fn ensure_player(player: &mut Option<Player>) -> Result<&mut Player, AudioError> {
         if player.is_none() {
             *player = Some(Player::new()?);
         }
-
-        // Load and play the file
-        if let Some(p) = player {
-            p.play_file(path).await?;
-        }
-
-        Ok(())
+        Ok(player.as_mut().expect("just initialised"))
     }
 }
 
 impl Drop for PlayerManager {
     fn drop(&mut self) {
-        // Best effort to shutdown
         let _ = self.command_tx.send(PlayerCommand::Shutdown);
     }
 }

--- a/crates/sonic-core/src/audio/traits.rs
+++ b/crates/sonic-core/src/audio/traits.rs
@@ -21,6 +21,7 @@ pub enum AudioFormatType {
     Wav,
     Ogg,
     Aac,
+    Opus,
     Unknown(String),
 }
 
@@ -31,8 +32,9 @@ impl AudioFormatType {
             "mp3" => Self::Mp3,
             "flac" => Self::Flac,
             "wav" => Self::Wav,
-            "ogg" => Self::Ogg,
+            "ogg" | "oga" => Self::Ogg,
             "aac" | "m4a" => Self::Aac,
+            "opus" => Self::Opus,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -40,6 +42,19 @@ impl AudioFormatType {
     /// Returns true if the format is supported for playback.
     pub fn is_supported(&self) -> bool {
         !matches!(self, Self::Unknown(_))
+    }
+
+    /// Returns a human-readable codec name for display.
+    pub fn codec_name(&self) -> &str {
+        match self {
+            Self::Mp3 => "MP3",
+            Self::Flac => "FLAC",
+            Self::Wav => "PCM",
+            Self::Ogg => "Vorbis",
+            Self::Aac => "AAC",
+            Self::Opus => "Opus",
+            Self::Unknown(_) => "Unknown",
+        }
     }
 
     /// Returns the format as a lowercase string.
@@ -50,6 +65,7 @@ impl AudioFormatType {
             Self::Wav => "wav",
             Self::Ogg => "ogg",
             Self::Aac => "aac",
+            Self::Opus => "opus",
             Self::Unknown(s) => s,
         }
     }
@@ -63,7 +79,16 @@ mod tests {
     fn format_type_from_extension() {
         assert_eq!(AudioFormatType::from_extension("mp3"), AudioFormatType::Mp3);
         assert_eq!(AudioFormatType::from_extension("MP3"), AudioFormatType::Mp3);
-        assert_eq!(AudioFormatType::from_extension("flac"), AudioFormatType::Flac);
+        assert_eq!(
+            AudioFormatType::from_extension("flac"),
+            AudioFormatType::Flac
+        );
+        assert_eq!(AudioFormatType::from_extension("ogg"), AudioFormatType::Ogg);
+        assert_eq!(AudioFormatType::from_extension("oga"), AudioFormatType::Ogg);
+        assert_eq!(
+            AudioFormatType::from_extension("opus"),
+            AudioFormatType::Opus
+        );
         assert_eq!(
             AudioFormatType::from_extension("xyz"),
             AudioFormatType::Unknown("xyz".to_string())
@@ -74,6 +99,7 @@ mod tests {
     fn format_type_is_supported() {
         assert!(AudioFormatType::Mp3.is_supported());
         assert!(AudioFormatType::Flac.is_supported());
+        assert!(AudioFormatType::Opus.is_supported());
         assert!(!AudioFormatType::Unknown("xyz".to_string()).is_supported());
     }
 }

--- a/crates/sonic-core/src/error.rs
+++ b/crates/sonic-core/src/error.rs
@@ -45,6 +45,10 @@ pub enum AudioError {
         to: String,
     },
 
+    /// Decode error (codec or container level)
+    #[error("decode error: {0}")]
+    Decode(String),
+
     /// Streaming / decoding error
     #[error("streaming error: {0}")]
     Streaming(String),

--- a/crates/sonic-core/src/lib.rs
+++ b/crates/sonic-core/src/lib.rs
@@ -7,5 +7,8 @@
 pub mod audio;
 pub mod error;
 
-pub use audio::{AudioFormat, AudioFormatType, PlayerManager, PlayerStatus};
+pub use audio::{
+    AudioBuffer, AudioDecoder, AudioFormat, AudioFormatInfo, AudioFormatType, PlayerManager,
+    PlayerStatus, SymphoniaDecoder,
+};
 pub use error::{AudioError, Error, Result};


### PR DESCRIPTION
## Summary

- Replace rodio's built-in `Decoder` with a `SymphoniaDecoder` that directly drives the Symphonia `FormatReader` + `Decoder` pipeline
- Add `AudioDecoder` trait as the unified interface for all decoders (`decode_next`, `seek`, `duration`, `format_info`)
- `SymphoniaDecoder` also implements `rodio::Source` so it can be pushed directly into a `rodio::Sink`
- Implement `seek()` by re-opening the file, seeking the Symphonia reader, and swapping the `rodio::Sink` source (preserves pause state)
- Wire `PlayerManager::Seek` command end-to-end; add wall-clock-based position tracking to `PlayerStatus`
- Populate `PlayerStatus.format` and `PlayerStatus.duration` from `AudioFormatInfo`
- Add `AudioFormatType::Opus` variant, `AudioError::Decode` variant, `decoder::registry::open()` factory

Supported formats: **MP3, FLAC, WAV, OGG Vorbis, AAC, OPUS**

## Test plan

- [x] `cargo test -p sonic-core` — 21 tests pass (0 failures)
- [x] `cargo build` — full workspace builds clean
- [x] `cargo clippy -p sonic-core -- -D warnings` — no warnings
- [x] `cargo fmt` — applied

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)