### PR TITLE
feat(audio): implement seek commands (#23)

### DIFF
--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Commands sent from UI to the application controller.
 #[derive(Debug)]
@@ -11,8 +12,11 @@ pub enum Command {
     Stop,
     /// Set volume (0.0 - 1.0)
     SetVolume(f32),
-    /// Skip forward by seconds
+    /// Seek to an absolute position within the current track
+    #[allow(dead_code)]
+    Seek(Duration),
+    /// Skip forward by the given number of seconds (relative to current position)
     SkipForward(f64),
-    /// Skip backward by seconds
+    /// Skip backward by the given number of seconds (relative to current position)
     SkipBackward(f64),
 }

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -51,21 +51,19 @@ impl Controller {
         debug!("Processing command: {:?}", cmd);
 
         match cmd {
-            Command::LoadFile(path) => {
-                match self.player.load_and_play(path.clone()).await {
-                    Ok(()) => {
-                        let _ = self.tx_event.send(Event::TrackLoaded { path }).await;
-                    }
-                    Err(e) => {
-                        let error = e.to_string();
-                        error!("Failed to load track: {}", error);
-                        let _ = self
-                            .tx_event
-                            .send(Event::TrackLoadFailed { path, error })
-                            .await;
-                    }
+            Command::LoadFile(path) => match self.player.load_and_play(path.clone()).await {
+                Ok(()) => {
+                    let _ = self.tx_event.send(Event::TrackLoaded { path }).await;
                 }
-            }
+                Err(e) => {
+                    let error = e.to_string();
+                    error!("Failed to load track: {}", error);
+                    let _ = self
+                        .tx_event
+                        .send(Event::TrackLoadFailed { path, error })
+                        .await;
+                }
+            },
             Command::TogglePlayback => {
                 let status = self.player.get_status().await;
                 let result = if status.is_playing {
@@ -87,13 +85,49 @@ impl Controller {
                     let _ = self.tx_event.send(Event::Error(e.to_string())).await;
                 }
             }
+            Command::Seek(position) => match self.player.seek(position).await {
+                Ok(actual) => {
+                    debug!("Seeked to {:?} (requested {:?})", actual, position);
+                    self.send_status().await;
+                }
+                Err(e) => {
+                    let _ = self.tx_event.send(Event::Error(e.to_string())).await;
+                }
+            },
             Command::SkipForward(seconds) => {
-                info!("Skip forward {} seconds", seconds);
-                // TODO: implement seeking
+                let status = self.player.get_status().await;
+                let offset = Duration::from_secs_f64(seconds);
+                let target = status.position.saturating_add(offset);
+                // Clamp to track duration when known.
+                let target = match status.duration {
+                    Some(d) => target.min(d),
+                    None => target,
+                };
+                info!("Skip forward {}s → {:?}", seconds, target);
+                match self.player.seek(target).await {
+                    Ok(actual) => {
+                        debug!("Skip forward seeked to {:?}", actual);
+                        self.send_status().await;
+                    }
+                    Err(e) => {
+                        let _ = self.tx_event.send(Event::Error(e.to_string())).await;
+                    }
+                }
             }
             Command::SkipBackward(seconds) => {
-                info!("Skip backward {} seconds", seconds);
-                // TODO: implement seeking
+                let status = self.player.get_status().await;
+                let offset = Duration::from_secs_f64(seconds);
+                let target = status.position.saturating_sub(offset);
+                info!("Skip backward {}s → {:?}", seconds, target);
+                match self.player.seek(target).await {
+                    Ok(actual) => {
+                        debug!("Skip backward seeked to {:?}", actual);
+                        self.send_status().await;
+                    }
+                    Err(e) => {
+                        let _ = self.tx_event.send(Event::Error(e.to_string())).await;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `Command::Seek(Duration)` for absolute position seeking from the UI seek bar
- Wire existing `SkipForward(f64)` / `SkipBackward(f64)` stubs to `PlayerManager::seek()` 
- `SkipForward` clamps target to track duration when known; `SkipBackward` uses `saturating_sub` for safe boundary handling
- Immediately emits `PlaybackStatus` after seek so the UI reports accurate position

`PlayerManager::seek()` and `SymphoniaDecoder::seek()` were implemented in #83 (Issue #24).

Closes #23

## Test plan

- [x] `just build` passes
- [x] `just clippy` clean
- [x] `just test` — 21 tests pass
- [x] Manual: load MP3/FLAC/WAV/OGG, SkipForward/SkipBackward update position in UI within ±500ms
- [x] Seek to position 0 (beginning) works
- [x] SkipForward at end of track clamps to duration, does not overflow