### PR TITLE
style: apply rustfmt to main and ui/mod

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6,7 +6,7 @@ mod app;
 mod ui;
 
 use tracing::info;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 fn main() -> anyhow::Result<()> {
     init_logging();

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -44,7 +44,9 @@ impl Ui {
             let tx = tx_cmd.clone();
             move || {
                 let tx = tx.clone();
-                tokio::spawn(async move { let _ = tx.send(Command::TogglePlayback).await; });
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::TogglePlayback).await;
+                });
             }
         });
 
@@ -52,7 +54,9 @@ impl Ui {
             let tx = tx_cmd.clone();
             move || {
                 let tx = tx.clone();
-                tokio::spawn(async move { let _ = tx.send(Command::Stop).await; });
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::Stop).await;
+                });
             }
         });
 
@@ -60,7 +64,9 @@ impl Ui {
             let tx = tx_cmd.clone();
             move || {
                 let tx = tx.clone();
-                tokio::spawn(async move { let _ = tx.send(Command::SkipBackward(10.0)).await; });
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::SkipBackward(10.0)).await;
+                });
             }
         });
 
@@ -68,7 +74,9 @@ impl Ui {
             let tx = tx_cmd.clone();
             move || {
                 let tx = tx.clone();
-                tokio::spawn(async move { let _ = tx.send(Command::SkipForward(10.0)).await; });
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::SkipForward(10.0)).await;
+                });
             }
         });
 
@@ -95,7 +103,9 @@ impl Ui {
                 if let Some(path) = path {
                     info!("Selected file: {}", path.display());
                     let tx = tx.clone();
-                    tokio::spawn(async move { let _ = tx.send(Command::LoadFile(path)).await; });
+                    tokio::spawn(async move {
+                        let _ = tx.send(Command::LoadFile(path)).await;
+                    });
                 }
             }
         });
@@ -108,7 +118,9 @@ impl Ui {
             let tx = tx_cmd.clone();
             move |volume| {
                 let tx = tx.clone();
-                tokio::spawn(async move { let _ = tx.send(Command::SetVolume(volume)).await; });
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::SetVolume(volume)).await;
+                });
             }
         });
     }


### PR DESCRIPTION
Applies `cargo fmt` formatting left over from previous sessions.

- `main.rs`: reorder imports to rustfmt canonical order
- `ui/mod.rs`: expand inline `tokio::spawn` closures to multi-line