### PR TITLE
feat: metadata extraction and NowPlayingInfo display (#25)

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
+use sonic_core::MetadataExtractor;
 use sonic_core::audio::player_manager::PlayerManager;
 
 use super::command::Command;
@@ -53,7 +54,19 @@ impl Controller {
         match cmd {
             Command::LoadFile(path) => match self.player.load_and_play(path.clone()).await {
                 Ok(()) => {
-                    let _ = self.tx_event.send(Event::TrackLoaded { path }).await;
+                    let meta_path = path.clone();
+                    let metadata = tokio::task::spawn_blocking(move || {
+                        MetadataExtractor::extract_with_fallback(&meta_path)
+                    })
+                    .await
+                    .unwrap_or_default();
+                    let _ = self
+                        .tx_event
+                        .send(Event::TrackLoaded {
+                            path,
+                            metadata: Box::new(metadata),
+                        })
+                        .await;
                 }
                 Err(e) => {
                     let error = e.to_string();

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use sonic_core::TrackMetadata;
+
 /// Events sent from the application controller to the UI.
 #[derive(Debug, Clone)]
 pub enum Event {
@@ -15,7 +17,10 @@ pub enum Event {
         format: Option<FormatInfo>,
     },
     /// Track loaded successfully
-    TrackLoaded { path: PathBuf },
+    TrackLoaded {
+        path: PathBuf,
+        metadata: Box<TrackMetadata>,
+    },
     /// Track failed to load
     TrackLoadFailed { path: PathBuf, error: String },
     /// General error

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -201,15 +201,26 @@ impl Ui {
                     }
                 }
 
-                if let Some(ref path) = track_path {
-                    let name = path
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("Unknown");
-                    ui.set_track_title(name.into());
+                match track_path {
+                    Some(ref path) => {
+                        let name = path
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or("Unknown");
+                        ui.set_current_track(name.into());
 
-                    if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-                        ui.set_file_format(ext.to_uppercase().into());
+                        if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+                            ui.set_file_format(ext.to_uppercase().into());
+                        }
+                    }
+                    None => {
+                        ui.set_current_track("No track loaded".into());
+                        // Clear metadata when no track is loaded.
+                        ui.set_track_title("".into());
+                        ui.set_track_artist("".into());
+                        ui.set_track_album("".into());
+                        ui.set_track_year("".into());
+                        ui.set_track_genre("".into());
                     }
                 }
 
@@ -220,8 +231,19 @@ impl Ui {
                 }
             }
 
-            Event::TrackLoaded { path } => {
+            Event::TrackLoaded { path, metadata } => {
                 info!("Track loaded: {}", path.display());
+                ui.set_track_title(metadata.title.unwrap_or_default().into());
+                ui.set_track_artist(metadata.artist.unwrap_or_default().into());
+                ui.set_track_album(metadata.album.unwrap_or_default().into());
+                ui.set_track_year(
+                    metadata
+                        .year
+                        .map(|y| y.to_string())
+                        .unwrap_or_default()
+                        .into(),
+                );
+                ui.set_track_genre(metadata.genre.unwrap_or_default().into());
             }
 
             Event::TrackLoadFailed { path, error } => {

--- a/crates/sonic-core/src/audio/metadata.rs
+++ b/crates/sonic-core/src/audio/metadata.rs
@@ -89,6 +89,22 @@ pub enum ArtworkType {
 pub struct MetadataExtractor;
 
 impl MetadataExtractor {
+    /// Extract metadata, applying a filename-based title fallback when tags are absent.
+    ///
+    /// Never returns an error — extraction failures produce a `TrackMetadata::default()`
+    /// with only the title populated from the file stem.
+    pub fn extract_with_fallback(path: &Path) -> TrackMetadata {
+        let mut meta = Self::extract_metadata(path).unwrap_or_default();
+        if meta.title.is_none() {
+            meta.title = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+                .or_else(|| Some("Unknown Track".to_string()));
+        }
+        meta
+    }
+
     /// Extract metadata from an audio file
     pub fn extract_metadata(path: &Path) -> Result<TrackMetadata, AudioError> {
         let extension = path
@@ -285,36 +301,36 @@ impl MetadataExtractor {
         Ok(metadata)
     }
 
-    /// Extract OGG Vorbis metadata
-    fn extract_ogg_metadata(_path: &Path) -> Result<TrackMetadata, AudioError> {
-        // Placeholder for OGG Vorbis metadata extraction
-        // Would use lewton or similar crate
-        Ok(TrackMetadata::default())
+    /// Extract OGG Vorbis metadata via Symphonia (reads Vorbis Comments).
+    fn extract_ogg_metadata(path: &Path) -> Result<TrackMetadata, AudioError> {
+        Self::extract_generic_metadata(path)
     }
 
-    /// Extract M4A/AAC metadata
-    fn extract_m4a_metadata(_path: &Path) -> Result<TrackMetadata, AudioError> {
-        // Placeholder for M4A metadata extraction
-        // Would use mp4parse or similar crate
-        Ok(TrackMetadata::default())
+    /// Extract M4A/AAC metadata via Symphonia (reads iTunes atoms).
+    fn extract_m4a_metadata(path: &Path) -> Result<TrackMetadata, AudioError> {
+        Self::extract_generic_metadata(path)
     }
 
-    /// Extract metadata using Symphonia (fallback)
+    /// Extract metadata using Symphonia's unified tag API.
+    ///
+    /// Handles all formats supported by Symphonia: OGG Vorbis, FLAC (when id3
+    /// is unavailable), M4A, OPUS, and any other probed container. Prefers
+    /// `StandardTagKey` variants for robust cross-format matching, then falls
+    /// back to raw string keys (e.g. Vorbis Comment uppercase keys).
     fn extract_generic_metadata(path: &Path) -> Result<TrackMetadata, AudioError> {
         use symphonia::core::formats::FormatOptions;
         use symphonia::core::io::MediaSourceStream;
-        use symphonia::core::meta::MetadataOptions;
+        use symphonia::core::meta::{MetadataOptions, StandardTagKey};
         use symphonia::core::probe::Hint;
 
         let file = std::fs::File::open(path)
             .map_err(|e| AudioError::Metadata(format!("Failed to open file: {}", e)))?;
 
-        let source = Box::new(file);
-        let mss = MediaSourceStream::new(source, Default::default());
+        let mss = MediaSourceStream::new(Box::new(file), Default::default());
 
         let mut hint = Hint::new();
-        if let Some(extension) = path.extension().and_then(|s| s.to_str()) {
-            hint.with_extension(extension);
+        if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+            hint.with_extension(ext);
         }
 
         let mut probed = symphonia::default::get_probe()
@@ -328,26 +344,63 @@ impl MetadataExtractor {
 
         let mut metadata = TrackMetadata::default();
 
-        // Extract metadata from Symphonia
-        if let Some(symphonia_metadata) = probed.metadata.get()
-            && let Some(current) = symphonia_metadata.current()
+        let meta_src = probed
+            .metadata
+            .get()
+            .or_else(|| Some(probed.format.metadata()));
+
+        if let Some(meta_log) = meta_src
+            && let Some(current) = meta_log.current()
         {
             for tag in current.tags() {
-                match tag.key.as_str() {
-                    "TITLE" => metadata.title = Some(tag.value.to_string()),
-                    "ARTIST" => metadata.artist = Some(tag.value.to_string()),
-                    "ALBUM" => metadata.album = Some(tag.value.to_string()),
-                    "DATE" => metadata.year = tag.value.to_string().parse().ok(),
-                    "TRACK" => metadata.track_number = tag.value.to_string().parse().ok(),
-                    "GENRE" => metadata.genre = Some(tag.value.to_string()),
-                    _ => {
-                        metadata
-                            .custom_tags
-                            .insert(tag.key.clone(), tag.value.to_string());
+                let value = tag.value.to_string();
+                if let Some(std_key) = tag.std_key {
+                    match std_key {
+                        StandardTagKey::TrackTitle => metadata.title = Some(value),
+                        StandardTagKey::Artist => metadata.artist = Some(value),
+                        StandardTagKey::Album => metadata.album = Some(value),
+                        StandardTagKey::AlbumArtist => {
+                            metadata.album_artist = Some(value);
+                        }
+                        StandardTagKey::Date => metadata.year = value.parse().ok(),
+                        StandardTagKey::TrackNumber => {
+                            metadata.track_number = value.parse().ok();
+                        }
+                        StandardTagKey::Genre => metadata.genre = Some(value),
+                        StandardTagKey::Composer => metadata.composer = Some(value),
+                        StandardTagKey::Comment => metadata.comment = Some(value),
+                        _ => {
+                            metadata.custom_tags.insert(tag.key.clone(), value);
+                        }
+                    }
+                } else {
+                    match tag.key.to_uppercase().as_str() {
+                        "TITLE" => metadata.title = Some(value),
+                        "ARTIST" => metadata.artist = Some(value),
+                        "ALBUM" => metadata.album = Some(value),
+                        "ALBUMARTIST" => metadata.album_artist = Some(value),
+                        "DATE" | "YEAR" => metadata.year = value.parse().ok(),
+                        "TRACKNUMBER" | "TRACK" => {
+                            metadata.track_number = value.parse().ok();
+                        }
+                        "GENRE" => metadata.genre = Some(value),
+                        "COMPOSER" => metadata.composer = Some(value),
+                        "COMMENT" => metadata.comment = Some(value),
+                        _ => {
+                            metadata.custom_tags.insert(tag.key.clone(), value);
+                        }
                     }
                 }
             }
         }
+
+        let file_info = std::fs::metadata(path)
+            .map_err(|e| AudioError::Metadata(format!("Failed to get file info: {}", e)))?;
+        metadata.file_size = Some(file_info.len());
+        metadata.format = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.to_uppercase());
 
         Ok(metadata)
     }

--- a/crates/sonic-core/src/audio/mod.rs
+++ b/crates/sonic-core/src/audio/mod.rs
@@ -8,5 +8,6 @@ pub mod player_manager;
 pub mod traits;
 
 pub use decoder::{AudioBuffer, AudioDecoder, AudioFormatInfo, SymphoniaDecoder};
+pub use metadata::{MetadataExtractor, TrackMetadata};
 pub use player_manager::{PlayerManager, PlayerStatus};
 pub use traits::{AudioFormat, AudioFormatType};

--- a/crates/sonic-core/src/lib.rs
+++ b/crates/sonic-core/src/lib.rs
@@ -8,7 +8,7 @@ pub mod audio;
 pub mod error;
 
 pub use audio::{
-    AudioBuffer, AudioDecoder, AudioFormat, AudioFormatInfo, AudioFormatType, PlayerManager,
-    PlayerStatus, SymphoniaDecoder,
+    AudioBuffer, AudioDecoder, AudioFormat, AudioFormatInfo, AudioFormatType, MetadataExtractor,
+    PlayerManager, PlayerStatus, SymphoniaDecoder, TrackMetadata,
 };
 pub use error::{AudioError, Error, Result};


### PR DESCRIPTION
## Summary

- `MetadataExtractor::extract_with_fallback()` — infallible extraction; falls back to filename as title when tags are missing
- OGG Vorbis and M4A/AAC now route through Symphonia instead of returning empty stubs
- `extract_generic_metadata` upgraded: uses `StandardTagKey` for robust cross-format matching (iTunes atoms, Vorbis Comments, etc.), then falls back to raw uppercase string keys
- `TrackMetadata` / `MetadataExtractor` exported from `sonic-core` public API
- `Event::TrackLoaded` gains `metadata: Box<TrackMetadata>` (boxed to avoid large-enum-variant warning)
- Controller extracts metadata via `spawn_blocking` immediately after successful track load
- UI: `TrackLoaded` event sets `track-title`, `track-artist`, `track-album`, `track-year`, `track-genre` in `UiState`
- UI: `PlaybackStatus` now correctly sets `current-track` (filename fallback path) instead of `track-title`; clears all metadata on stop

The `NowPlayingInfo` Slint component already had all required bindings — no Slint changes needed.

Closes #25

## Test plan

- [x] `just build` passes
- [x] `just clippy` clean
- [x] `just test` — 21 tests pass
- [x] Manual: load MP3 with ID3 tags → title/artist/album/year/genre appear in NowPlayingInfo panel
- [x] Manual: load FLAC with Vorbis Comments → metadata shown correctly
- [x] Manual: load OGG → metadata shown (previously stub, now via Symphonia)
- [x] Manual: load WAV (no tags) → filename used as title, artist/album empty
- [x] Manual: Stop → all metadata fields clear
- [x] Manual: load second track → metadata updates to new track