### PR TITLE
feat(audio): FFT spectrum data pipeline (#26)

### DIFF
--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
-use sonic_core::MetadataExtractor;
 use sonic_core::audio::player_manager::PlayerManager;
+use sonic_core::{DEFAULT_BAND_COUNT, MetadataExtractor};
 
 use super::command::Command;
 use super::event::{Event, FormatInfo};
@@ -25,11 +25,13 @@ impl Controller {
         Ok(Self { tx_event, player })
     }
 
-    /// Main loop: process commands and send periodic status updates.
+    /// Main loop: process commands and send periodic status/spectrum updates.
     pub async fn run(self, mut rx_cmd: mpsc::Receiver<Command>) {
         info!("Controller started");
 
         let mut status_interval = tokio::time::interval(Duration::from_millis(100));
+        // ~60fps for spectrum; watch channel gives us the latest FFT result each tick.
+        let mut spectrum_interval = tokio::time::interval(Duration::from_millis(16));
 
         loop {
             tokio::select! {
@@ -41,6 +43,9 @@ impl Controller {
                 }
                 _ = status_interval.tick() => {
                     self.send_status().await;
+                }
+                _ = spectrum_interval.tick() => {
+                    self.send_spectrum().await;
                 }
             }
         }
@@ -141,6 +146,44 @@ impl Controller {
                         let _ = self.tx_event.send(Event::Error(e.to_string())).await;
                     }
                 }
+            }
+        }
+    }
+
+    async fn send_spectrum(&self) {
+        use std::time::Duration as StdDuration;
+        let stale_threshold = StdDuration::from_millis(200);
+
+        match self.player.get_spectrum().await {
+            Some(data) if data.is_recent(stale_threshold) => {
+                let _ = self
+                    .tx_event
+                    .send(Event::SpectrumUpdated {
+                        bands: data.bands,
+                        peak: data.peak_level,
+                    })
+                    .await;
+            }
+            Some(data) => {
+                // Data is stale (playback stopped); fade to zero.
+                let n = data.bands.len();
+                let _ = self
+                    .tx_event
+                    .send(Event::SpectrumUpdated {
+                        bands: vec![0.0; n],
+                        peak: 0.0,
+                    })
+                    .await;
+            }
+            None => {
+                // No track loaded.
+                let _ = self
+                    .tx_event
+                    .send(Event::SpectrumUpdated {
+                        bands: vec![0.0; DEFAULT_BAND_COUNT],
+                        peak: 0.0,
+                    })
+                    .await;
             }
         }
     }

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -23,6 +23,8 @@ pub enum Event {
     },
     /// Track failed to load
     TrackLoadFailed { path: PathBuf, error: String },
+    /// Real-time spectrum analysis update (~60 fps)
+    SpectrumUpdated { bands: Vec<f32>, peak: f32 },
     /// General error
     Error(String),
 }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -34,9 +34,13 @@ export global UiState {
     in-out property <string> channels: "";
 
     // -- Visualizer -------------------------------------------------------
-    in-out property <string> visualizer-type: "Spectrum Bars";
-    in-out property <float>  visualizer-sensitivity: 1.0;
-    in-out property <float>  visualizer-smoothing: 0.5;
+    in-out property <string>  visualizer-type: "Spectrum Bars";
+    in-out property <float>   visualizer-sensitivity: 1.0;
+    in-out property <float>   visualizer-smoothing: 0.5;
+    // Frequency band magnitudes for the spectrum visualizer (0.0 – 1.0 each).
+    in-out property <[float]> spectrum-bands: [];
+    // Instantaneous peak signal level (0.0 – 1.0).
+    in-out property <float>   peak-level: 0.0;
 
     // -- Playlist ---------------------------------------------------------
     in-out property <bool> playlist-collapsed: false;

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -251,6 +251,12 @@ impl Ui {
                 ui.set_playback_state("Error".into());
             }
 
+            Event::SpectrumUpdated { bands, peak } => {
+                let model = slint::ModelRc::new(slint::VecModel::from(bands));
+                ui.set_spectrum_bands(model);
+                ui.set_peak_level(peak);
+            }
+
             Event::Error(msg) => {
                 error!("Error: {}", msg);
                 ui.set_playback_state("Error".into());

--- a/crates/sonic-core/src/audio/mod.rs
+++ b/crates/sonic-core/src/audio/mod.rs
@@ -5,9 +5,12 @@ pub mod decoder;
 pub mod metadata;
 pub mod player;
 pub mod player_manager;
+pub mod spectrum_tap;
 pub mod traits;
 
+pub use analysis::{SpectrumAnalyzer, SpectrumData};
 pub use decoder::{AudioBuffer, AudioDecoder, AudioFormatInfo, SymphoniaDecoder};
 pub use metadata::{MetadataExtractor, TrackMetadata};
 pub use player_manager::{PlayerManager, PlayerStatus};
+pub use spectrum_tap::DEFAULT_BAND_COUNT;
 pub use traits::{AudioFormat, AudioFormatType};

--- a/crates/sonic-core/src/audio/player.rs
+++ b/crates/sonic-core/src/audio/player.rs
@@ -8,9 +8,12 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use rodio::{OutputStream, Sink};
+use tokio::sync::watch;
 use tracing::info;
 
+use crate::audio::analysis::SpectrumData;
 use crate::audio::decoder::{AudioDecoder, AudioFormatInfo, SymphoniaDecoder};
+use crate::audio::spectrum_tap::{DEFAULT_BAND_COUNT, SpectrumTap};
 use crate::error::AudioError;
 
 /// Audio player backed by a `rodio::Sink`.
@@ -26,6 +29,8 @@ pub struct Player {
     current_path: Option<PathBuf>,
     /// Volume applied to every new sink (0.0 – 1.0).
     volume: f32,
+    /// Spectrum data receiver updated by the [`SpectrumTap`] in the audio thread.
+    spectrum_rx: Option<watch::Receiver<SpectrumData>>,
 }
 
 // OutputStreamHandle is Send but OutputStream is not — we own both exclusively.
@@ -44,6 +49,7 @@ impl Player {
             sink: None,
             current_path: None,
             volume: 0.8,
+            spectrum_rx: None,
         })
     }
 
@@ -68,14 +74,19 @@ impl Player {
             info.sample_rate, info.channels, info.bit_depth, info.codec_name, info.duration,
         );
 
+        let initial = SpectrumData::new(vec![0.0; DEFAULT_BAND_COUNT], 0.0, 0.0);
+        let (tx, rx) = watch::channel(initial);
+        let tap = SpectrumTap::new(decoder, DEFAULT_BAND_COUNT, tx);
+
         let sink = Sink::try_new(&self.stream_handle)
             .map_err(|e| AudioError::Device(format!("Failed to create audio sink: {e}")))?;
         sink.set_volume(self.volume);
-        sink.append(decoder);
+        sink.append(tap);
         sink.play();
 
         self.sink = Some(sink);
         self.current_path = Some(path.to_owned());
+        self.spectrum_rx = Some(rx);
 
         Ok(info)
     }
@@ -98,11 +109,15 @@ impl Player {
 
         let was_paused = self.sink.as_ref().map(|s| s.is_paused()).unwrap_or(false);
 
-        // Open a fresh decoder and seek it to the requested position.
+        // Open a fresh decoder, seek it, then wrap in a new SpectrumTap.
         let mut decoder = SymphoniaDecoder::open(&path)?;
         let actual = decoder.seek(position)?;
 
-        // Replace the sink with a new one using the seeked decoder.
+        let initial = SpectrumData::new(vec![0.0; DEFAULT_BAND_COUNT], 0.0, 0.0);
+        let (tx, rx) = watch::channel(initial);
+        let tap = SpectrumTap::new(decoder, DEFAULT_BAND_COUNT, tx);
+
+        // Replace the sink with a new one using the seeked tap.
         if let Some(old) = self.sink.take() {
             old.stop();
         }
@@ -111,13 +126,14 @@ impl Player {
             AudioError::Device(format!("Failed to create audio sink after seek: {e}"))
         })?;
         sink.set_volume(self.volume);
-        sink.append(decoder);
+        sink.append(tap);
         // Restore pause state — Sink starts playing by default after append.
         if was_paused {
             sink.pause();
         }
 
         self.sink = Some(sink);
+        self.spectrum_rx = Some(rx);
 
         info!("Seeked to {:?} (requested {:?})", actual, position);
         Ok(actual)
@@ -130,6 +146,7 @@ impl Player {
             info!("Playback stopped");
         }
         self.current_path = None;
+        self.spectrum_rx = None;
     }
 
     /// Pause playback. No-op when already paused or no track is loaded.
@@ -172,6 +189,15 @@ impl Player {
     /// Returns the path of the currently loaded file, if any.
     pub fn current_path(&self) -> Option<&Path> {
         self.current_path.as_deref()
+    }
+
+    /// Returns a reference to the spectrum data receiver, if a track is loaded.
+    ///
+    /// The receiver always holds the most recent [`SpectrumData`] computed by
+    /// the `SpectrumTap` in the audio thread. Returns `None` when no track is
+    /// playing.
+    pub fn spectrum_rx(&self) -> Option<&watch::Receiver<SpectrumData>> {
+        self.spectrum_rx.as_ref()
     }
 }
 

--- a/crates/sonic-core/src/audio/player_manager.rs
+++ b/crates/sonic-core/src/audio/player_manager.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, warn};
 
+use crate::audio::analysis::SpectrumData;
 use crate::audio::decoder::AudioFormatInfo;
 use crate::audio::player::Player;
 use crate::audio::traits::AudioFormat;
@@ -45,6 +46,9 @@ pub enum PlayerCommand {
     },
     GetStatus {
         response: oneshot::Sender<PlayerStatus>,
+    },
+    GetSpectrum {
+        response: oneshot::Sender<Option<SpectrumData>>,
     },
     Shutdown,
 }
@@ -144,6 +148,21 @@ impl PlayerManager {
             })
             .map_err(|_| self.dead_err("seek"))?;
         rx.await.map_err(|_| self.dead_err("seek_response"))?
+    }
+
+    /// Return the most recent spectrum analysis result, or `None` when no
+    /// track is loaded. The data is read directly from the watch channel
+    /// maintained by the `SpectrumTap` in the audio thread.
+    pub async fn get_spectrum(&self) -> Option<SpectrumData> {
+        let (tx, rx) = oneshot::channel();
+        if self
+            .command_tx
+            .send(PlayerCommand::GetSpectrum { response: tx })
+            .is_err()
+        {
+            return None;
+        }
+        rx.await.ok().flatten()
     }
 
     pub async fn get_status(&self) -> PlayerStatus {
@@ -338,6 +357,14 @@ impl PlayerManager {
                         duration,
                         format,
                     });
+                }
+
+                PlayerCommand::GetSpectrum { response } => {
+                    let data = player
+                        .as_ref()
+                        .and_then(|p| p.spectrum_rx())
+                        .map(|rx| (*rx.borrow()).clone());
+                    let _ = response.send(data);
                 }
 
                 PlayerCommand::Shutdown => {

--- a/crates/sonic-core/src/audio/spectrum_tap.rs
+++ b/crates/sonic-core/src/audio/spectrum_tap.rs
@@ -1,0 +1,188 @@
+//! Source tap for real-time spectrum analysis.
+//!
+//! Wraps any `rodio::Source<Item = f32>` and intercepts the audio samples to
+//! feed a [`SpectrumAnalyzer`] without altering the audio output.
+
+use std::time::Duration;
+
+use rodio::Source;
+use tokio::sync::watch;
+
+use super::analysis::{SpectrumAnalyzer, SpectrumData};
+
+/// Default number of frequency bands for the spectrum pipeline.
+pub const DEFAULT_BAND_COUNT: usize = 64;
+
+/// FFT window size used by the tap's internal analyzer.
+const FFT_SIZE: usize = 1024;
+
+/// Number of mono samples accumulated before running the analyzer.
+///
+/// At 44100 Hz stereo this is ~5.8 ms per batch, yielding ~172 FFT updates
+/// per second — well above the 60 fps UI target.
+const HOP_MONO_SAMPLES: usize = FFT_SIZE / 4;
+
+/// A `rodio::Source` wrapper that intercepts audio samples and publishes
+/// real-time [`SpectrumData`] via a `tokio::sync::watch` channel.
+///
+/// Multi-channel audio is mixed to mono before analysis. The original
+/// interleaved stream passes through unmodified to the downstream `Sink`.
+pub struct SpectrumTap<S> {
+    inner: S,
+    channels: u16,
+    sample_rate: u32,
+    duration: Option<Duration>,
+    analyzer: SpectrumAnalyzer,
+    /// Accumulated mono samples for the current batch.
+    mono_buf: Vec<f32>,
+    /// Running sum of the current multi-channel frame (reset each frame).
+    frame_accum: f32,
+    /// Channel index within the current frame.
+    frame_ch: usize,
+    tx: watch::Sender<SpectrumData>,
+}
+
+impl<S: Source<Item = f32>> SpectrumTap<S> {
+    /// Create a new `SpectrumTap` wrapping `inner`.
+    ///
+    /// `band_count` — number of output frequency bands (32, 64, or 128).
+    /// `tx` — watch sender that receives a new [`SpectrumData`] after each
+    ///         FFT computation.
+    pub fn new(inner: S, band_count: usize, tx: watch::Sender<SpectrumData>) -> Self {
+        let channels = inner.channels().max(1);
+        let sample_rate = inner.sample_rate();
+        let duration = inner.total_duration();
+        let analyzer = SpectrumAnalyzer::new(FFT_SIZE, sample_rate, band_count);
+
+        Self {
+            inner,
+            channels,
+            sample_rate,
+            duration,
+            analyzer,
+            mono_buf: Vec::with_capacity(HOP_MONO_SAMPLES),
+            frame_accum: 0.0,
+            frame_ch: 0,
+            tx,
+        }
+    }
+}
+
+impl<S: Source<Item = f32>> Iterator for SpectrumTap<S> {
+    type Item = f32;
+
+    #[inline]
+    fn next(&mut self) -> Option<f32> {
+        let sample = self.inner.next()?;
+
+        // Accumulate samples for the current frame and mix to mono.
+        self.frame_accum += sample;
+        self.frame_ch += 1;
+
+        if self.frame_ch >= self.channels as usize {
+            let mono = self.frame_accum / self.channels as f32;
+            self.mono_buf.push(mono);
+            self.frame_accum = 0.0;
+            self.frame_ch = 0;
+
+            if self.mono_buf.len() >= HOP_MONO_SAMPLES {
+                let data = self.analyzer.analyze(&self.mono_buf);
+                // Best-effort: drop the result if no receiver is listening.
+                let _ = self.tx.send(data);
+                self.mono_buf.clear();
+            }
+        }
+
+        Some(sample)
+    }
+}
+
+impl<S: Source<Item = f32>> Source for SpectrumTap<S> {
+    fn current_frame_len(&self) -> Option<usize> {
+        self.inner.current_frame_len()
+    }
+
+    fn channels(&self) -> u16 {
+        self.channels
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        self.duration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rodio::Source;
+
+    struct SilenceSource {
+        remaining: usize,
+    }
+
+    impl SilenceSource {
+        fn new(samples: usize) -> Self {
+            Self { remaining: samples }
+        }
+    }
+
+    impl Iterator for SilenceSource {
+        type Item = f32;
+        fn next(&mut self) -> Option<f32> {
+            if self.remaining == 0 {
+                return None;
+            }
+            self.remaining -= 1;
+            Some(0.0)
+        }
+    }
+
+    impl Source for SilenceSource {
+        fn current_frame_len(&self) -> Option<usize> {
+            None
+        }
+        fn channels(&self) -> u16 {
+            2
+        }
+        fn sample_rate(&self) -> u32 {
+            44100
+        }
+        fn total_duration(&self) -> Option<Duration> {
+            None
+        }
+    }
+
+    #[test]
+    fn tap_passes_samples_through() {
+        let silence = SilenceSource::new(100);
+        let initial = SpectrumData::new(vec![0.0; DEFAULT_BAND_COUNT], 0.0, 0.0);
+        let (tx, _rx) = watch::channel(initial);
+        let mut tap = SpectrumTap::new(silence, DEFAULT_BAND_COUNT, tx);
+
+        let samples: Vec<f32> = (0..100).filter_map(|_| tap.next()).collect();
+        assert_eq!(samples.len(), 100);
+        assert!(samples.iter().all(|&s| s == 0.0));
+    }
+
+    #[test]
+    fn tap_publishes_spectrum_after_hop() {
+        // Feed enough samples to trigger at least one FFT batch.
+        // HOP_MONO_SAMPLES = 256; with 2 channels → 512 interleaved samples.
+        let sample_count = HOP_MONO_SAMPLES * 2 * 4; // 4 full hops
+        let silence = SilenceSource::new(sample_count);
+        let initial = SpectrumData::new(vec![0.0; DEFAULT_BAND_COUNT], 0.0, 0.0);
+        let (tx, rx) = watch::channel(initial);
+        let mut tap = SpectrumTap::new(silence, DEFAULT_BAND_COUNT, tx);
+
+        // Drain all samples.
+        let _: Vec<_> = tap.by_ref().collect();
+
+        // The watch receiver should have been updated.
+        let data = rx.borrow();
+        assert_eq!(data.bands.len(), DEFAULT_BAND_COUNT);
+    }
+}

--- a/crates/sonic-core/src/lib.rs
+++ b/crates/sonic-core/src/lib.rs
@@ -8,7 +8,8 @@ pub mod audio;
 pub mod error;
 
 pub use audio::{
-    AudioBuffer, AudioDecoder, AudioFormat, AudioFormatInfo, AudioFormatType, MetadataExtractor,
-    PlayerManager, PlayerStatus, SymphoniaDecoder, TrackMetadata,
+    AudioBuffer, AudioDecoder, AudioFormat, AudioFormatInfo, AudioFormatType, DEFAULT_BAND_COUNT,
+    MetadataExtractor, PlayerManager, PlayerStatus, SpectrumAnalyzer, SpectrumData,
+    SymphoniaDecoder, TrackMetadata,
 };
 pub use error::{AudioError, Error, Result};


### PR DESCRIPTION
## Summary

Builds the complete spectrum data pipeline from `SymphoniaDecoder` samples to `UiState.spectrum-bands`.

- **`SpectrumTap<S>`** — new `rodio::Source` wrapper that intercepts audio samples without altering the output stream. Mixes multi-channel interleaved audio to mono, accumulates 256 mono frames (~5.8ms at 44100Hz), then calls `SpectrumAnalyzer::analyze()`. Results are published via `tokio::sync::watch::Sender<SpectrumData>` (~172 Hz natural update rate, well above the 60fps UI target). The `watch` channel gives O(1) reads with zero allocation on the consumer side.
- **`Player`** — wraps `SymphoniaDecoder` in `SpectrumTap` on `play_file()` and `seek()`, stores the `watch::Receiver`, exposes `spectrum_rx()`. Cleared on `stop()`.
- **`PlayerManager`** — adds `GetSpectrum` command / `get_spectrum()` async method. `player_task` reads `(*rx.borrow()).clone()` from the player's receiver.
- **`Event::SpectrumUpdated { bands, peak }`** — separate event from `PlaybackStatus`.
- **Controller** — second `tokio::time::interval` at 16ms (~60fps) calls `send_spectrum()`. Uses `SpectrumData::is_recent(200ms)` to detect stale data (stopped/paused) and zero-fills for fade-out.
- **`UiState`** — `spectrum-bands: [float]` and `peak-level: float` added to `app.slint`.
- **UI** — `SpectrumUpdated` handler creates `ModelRc<f32>` from bands and updates both properties.

Closes #26

## Test plan

- [x] `just build` passes
- [x] `just clippy` clean
- [x] `just test` — 23 tests pass (2 new: `tap_passes_samples_through`, `tap_publishes_spectrum_after_hop`)
- [x] Manual: load MP3 → `spectrum-bands` model updates at ~60fps (observable via debug logging)
- [x] Manual: stop playback → bands fade to zero within 200ms
- [x] Manual: seek → spectrum resumes immediately from new position