### PR TITLE
feat(ui): wire live spectrum bands to VisualizerCanvas with peak hold

### DIFF
--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -83,7 +83,7 @@ export global UiState {
 export component AppWindow inherits Window {
     title: "Sonic Flow";
     width: 1400px;
-    height: 900px;
+    height: 750px;
     background: ColorTheme.background;
 
     VerticalBox {

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -83,19 +83,23 @@ export global UiState {
 export component AppWindow inherits Window {
     title: "Sonic Flow";
     width: 1400px;
-    height: 750px;
+    height: 600px;
     background: ColorTheme.background;
 
     VerticalBox {
         padding: 20px;
         spacing: 20px;
 
-        // Main content area — vertical-stretch: 1 lets Slint give it the
-        // remaining height after PlayerControls claims its fixed 90px.
+        // Clip wrapper: ensures NowPlayingInfo overflow never pushes
+        // PlayerControls off-screen.
+        Rectangle {
+            vertical-stretch: 1;
+            clip: true;
+
         HorizontalBox {
             spacing: 20px;
-            horizontal-stretch: 1;
-            vertical-stretch: 1;
+            width: parent.width;
+            height: parent.height;
 
             // Left panel - Playlist
             PlaylistView {
@@ -153,7 +157,8 @@ export component AppWindow inherits Window {
                 bitrate:        UiState.bitrate;
                 channels:       UiState.channels;
             }
-        }
+        } // HorizontalBox
+        } // clip Rectangle
 
         // Bottom control bar
         PlayerControls {

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -121,6 +121,8 @@ export component AppWindow inherits Window {
                 is-playing:      UiState.is-playing;
                 sensitivity:     UiState.visualizer-sensitivity;
                 smoothing:       UiState.visualizer-smoothing;
+                spectrum-data:   UiState.spectrum-bands;
+                peak-level:      UiState.peak-level;
 
                 visualizer-changed(t)   => { UiState.visualizer-changed(t); }
                 sensitivity-changed(v)  => { UiState.visualizer-sensitivity-changed(v); }

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -83,7 +83,7 @@ export global UiState {
 export component AppWindow inherits Window {
     title: "Sonic Flow";
     width: 1400px;
-    height: 600px;
+    height: 900px;
     background: ColorTheme.background;
 
     VerticalBox {

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -90,10 +90,12 @@ export component AppWindow inherits Window {
         padding: 20px;
         spacing: 20px;
 
-        // Main content area
+        // Main content area — vertical-stretch: 1 lets Slint give it the
+        // remaining height after PlayerControls claims its fixed 90px.
         HorizontalBox {
             spacing: 20px;
             horizontal-stretch: 1;
+            vertical-stretch: 1;
 
             // Left panel - Playlist
             PlaylistView {

--- a/app/src/ui/components/track_info.slint
+++ b/app/src/ui/components/track_info.slint
@@ -354,10 +354,8 @@ export component NowPlayingInfo inherits Panel {
             channels: root.channels;
         }
 
-        Rectangle { vertical-stretch: 1; }
-
-        // トラック統計（将来的な拡張用）
-        if root.is-playing: VerticalBox {
+        // トラック統計
+        if root.file-format != "": VerticalBox {
             spacing: 6px;
             
             GlowText {

--- a/app/src/ui/components/track_info.slint
+++ b/app/src/ui/components/track_info.slint
@@ -290,7 +290,7 @@ export component NowPlayingInfo inherits Panel {
 
         // アルバムアート
         AlbumArt {
-            height: 200px;
+            height: 120px;
             artwork: root.album-artwork;
             is-playing: root.is-playing;
         }

--- a/app/src/ui/components/visualizer_canvas.slint
+++ b/app/src/ui/components/visualizer_canvas.slint
@@ -288,7 +288,7 @@ export component VisualizerCanvas inherits Panel {
             border-radius: ColorTheme.border-radius;
             border-width: 2px;
             border-color: root.is-playing ? ColorTheme.primary : ColorTheme.border;
-            min-height: 350px;
+            min-height: 200px;
             vertical-stretch: 1;
             
             animate border-color { duration: ColorTheme.animation-normal; }
@@ -299,8 +299,8 @@ export component VisualizerCanvas inherits Panel {
 
                 // Bars — always visible; zeros animate to zero height on stop (fade-out)
                 if root.spectrum-data.length > 0: HorizontalBox {
+                    vertical-stretch: 1;
                     spacing: 2px;
-                    alignment: center;
 
                     for band-value[i] in root.spectrum-data: SpectrumBar {
                         height-ratio: Math.min(1.0, Math.max(0.0, band-value * root.sensitivity));
@@ -315,6 +315,7 @@ export component VisualizerCanvas inherits Panel {
 
                 // Placeholder shown only before any spectrum data arrives
                 if root.spectrum-data.length == 0: VerticalBox {
+                    vertical-stretch: 1;
                     alignment: center;
                     spacing: 20px;
 

--- a/app/src/ui/components/visualizer_canvas.slint
+++ b/app/src/ui/components/visualizer_canvas.slint
@@ -6,11 +6,27 @@ component SpectrumBar inherits Rectangle {
     in property <float> height-ratio: 0.0; // 0.0 to 1.0
     in property <color> bar-color: ColorTheme.spectrum-gradient-start;
     in property <int> bar-index: 0;
-    
-    width: 8px;
+
+    horizontal-stretch: 1;
+    min-width: 2px;
     background: ColorTheme.visualizer-bg;
-    
-    // バーの描画
+
+    // Peak hold: jumps up instantly, decays at ~0.01/frame (≈1.6 s from 1.0 → 0.0)
+    property <float> held-peak: 0.0;
+
+    Timer {
+        interval: 16ms;
+        running: true;
+        triggered => {
+            if root.height-ratio >= held-peak {
+                held-peak = root.height-ratio;
+            } else {
+                held-peak = Math.max(0.0, held-peak - 0.01);
+            }
+        }
+    }
+
+    // Bar fill
     Rectangle {
         width: parent.width - 2px;
         height: parent.height * root.height-ratio;
@@ -22,24 +38,20 @@ component SpectrumBar inherits Rectangle {
             root.bar-color.darker(0.3)
         );
         border-radius: 2px;
-        
-        // グロー効果
         drop-shadow-blur: 8px;
         drop-shadow-color: root.bar-color;
         drop-shadow-offset-y: 0px;
-        
         animate height { duration: 50ms; }
     }
-    
-    // ピークインジケーター
-    if root.height-ratio > 0.8: Rectangle {
+
+    // Peak hold indicator — fades out as the peak decays
+    if root.held-peak > 0.02: Rectangle {
         width: parent.width;
         height: 2px;
-        y: parent.height * (1.0 - root.height-ratio) - 2px;
+        y: parent.height * (1.0 - root.held-peak) - 2px;
         background: ColorTheme.text-primary;
+        opacity: root.held-peak;
         border-radius: 1px;
-        
-        animate y { duration: 100ms; }
     }
 }
 
@@ -134,10 +146,8 @@ export component VisualizerCanvas inherits Panel {
     in-out property <bool> is-playing: false;
     in-out property <float> sensitivity: 1.0;
     in-out property <float> smoothing: 0.8;
-    in-out property <[float]> spectrum-data: [
-        0.1, 0.2, 0.15, 0.3, 0.25, 0.4, 0.35, 0.5, 0.45, 0.6, 0.55, 0.7, 0.65, 0.8, 0.75, 0.9,
-        0.85, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.05, 0.08, 0.12, 0.18, 0.25, 0.35, 0.45, 0.55
-    ];
+    in-out property <[float]> spectrum-data: [];
+    in property <float> peak-level: 0.0;
     
     // コールバック
     callback visualizer-changed(string);
@@ -283,33 +293,37 @@ export component VisualizerCanvas inherits Panel {
             animate border-color { duration: ColorTheme.animation-normal; }
             
             // ビジュアライザーコンテンツ
-            if root.visualizer-type == "Spectrum Bars": Rectangle {
+            if root.visualizer-type == "Spectrum Bars": VerticalBox {
                 padding: 20px;
-                
-                if root.is-playing: HorizontalBox {
+
+                // Bars — always visible; zeros animate to zero height on stop (fade-out)
+                if root.spectrum-data.length > 0: HorizontalBox {
                     spacing: 2px;
                     alignment: center;
-                    
-                    for i in 32: SpectrumBar {
-                        height-ratio: i < spectrum-data.length ? spectrum-data[i] * root.sensitivity : 0.0;
-                        bar-color: i < 11 ? ColorTheme.spectrum-gradient-start :
-                                  i < 22 ? ColorTheme.spectrum-gradient-mid :
-                                  ColorTheme.spectrum-gradient-end;
+
+                    for band-value[i] in root.spectrum-data: SpectrumBar {
+                        height-ratio: Math.min(1.0, Math.max(0.0, band-value * root.sensitivity));
+                        bar-color: i < root.spectrum-data.length / 3
+                                 ? ColorTheme.spectrum-gradient-start
+                                 : i < root.spectrum-data.length * 2 / 3
+                                   ? ColorTheme.spectrum-gradient-mid
+                                   : ColorTheme.spectrum-gradient-end;
                         bar-index: i;
                     }
                 }
-                
-                if !root.is-playing: VerticalBox {
+
+                // Placeholder shown only before any spectrum data arrives
+                if root.spectrum-data.length == 0: VerticalBox {
                     alignment: center;
                     spacing: 20px;
-                    
+
                     GlowText {
                         text: "♫";
                         font-size: 72px;
                         color: ColorTheme.text-muted;
                         horizontal-alignment: center;
                     }
-                    
+
                     GlowText {
                         text: "Play music to see visualization";
                         color: ColorTheme.text-secondary;
@@ -418,26 +432,26 @@ export component VisualizerCanvas inherits Panel {
 
             Rectangle { horizontal-stretch: 1; }
 
-            // 品質インジケーター
+            // ピークレベルインジケーター
             HorizontalBox {
                 spacing: ColorTheme.spacing-small;
-                
+
                 GlowText {
-                    text: "Quality:";
+                    text: "Level:";
                     color: ColorTheme.text-muted;
                     font-size: ColorTheme.font-size-small;
                     vertical-alignment: center;
                 }
-                
+
                 ProgressIndicator {
                     width: 60px;
                     height: 6px;
-                    progress: root.is-playing ? 0.85 : 0.0;
+                    progress: root.peak-level;
                     indicator-color: ColorTheme.primary;
                 }
-                
+
                 GlowText {
-                    text: "85%";
+                    text: Math.round(root.peak-level * 100) + "%";
                     color: ColorTheme.text-muted;
                     font-size: ColorTheme.font-size-tiny;
                     vertical-alignment: center;

--- a/app/src/ui/components/visualizer_canvas.slint
+++ b/app/src/ui/components/visualizer_canvas.slint
@@ -289,6 +289,7 @@ export component VisualizerCanvas inherits Panel {
             border-width: 2px;
             border-color: root.is-playing ? ColorTheme.primary : ColorTheme.border;
             min-height: 350px;
+            vertical-stretch: 1;
             
             animate border-color { duration: ColorTheme.animation-normal; }
             

--- a/app/src/ui/components/visualizer_canvas.slint
+++ b/app/src/ui/components/visualizer_canvas.slint
@@ -165,7 +165,6 @@ export component VisualizerCanvas inherits Panel {
         // ビジュアライザー制御パネル
         HorizontalBox {
             spacing: ColorTheme.spacing;
-            height: 45px;
 
             GlowText {
                 text: "Visualizer";

--- a/crates/sonic-core/src/audio/analysis.rs
+++ b/crates/sonic-core/src/audio/analysis.rs
@@ -143,17 +143,13 @@ impl SpectrumAnalyzer {
         self.logarithmic_spacing = logarithmic;
     }
 
-    /// Analyze audio samples and return spectrum data
+    /// Analyze audio samples and return spectrum data.
     ///
-    /// # Arguments
-    ///
-    /// * `samples` - Audio samples to analyze (mono)
-    ///
-    /// # Returns
-    ///
-    /// Spectrum data with frequency bands
-    pub fn analyze(&mut self, samples: &[f32]) -> SpectrumData {
-        // Add samples to overlap buffer
+    /// Returns `None` when the internal overlap buffer has not yet accumulated
+    /// enough samples to trigger an FFT window. Returns `Some` whenever at
+    /// least one FFT window has been processed, so callers can avoid
+    /// overwriting a previous real result with stale zeros.
+    pub fn analyze(&mut self, samples: &[f32]) -> Option<SpectrumData> {
         for &sample in samples {
             self.overlap_buffer.push_back(sample);
         }
@@ -161,55 +157,44 @@ impl SpectrumAnalyzer {
         let mut all_bands = Vec::new();
         let hop_size = (self.fft_size as f32 * (1.0 - self.overlap_ratio)) as usize;
 
-        // Process overlapping windows
         while self.overlap_buffer.len() >= self.fft_size {
-            // Fill input buffer with windowed samples
             for (i, sample) in self.overlap_buffer.iter().take(self.fft_size).enumerate() {
                 let windowed_sample = sample * self.window[i];
                 self.input_buffer[i] = Complex::new(windowed_sample, 0.0);
             }
 
-            // Remove processed samples (hop size)
             for _ in 0..hop_size.min(self.overlap_buffer.len()) {
                 self.overlap_buffer.pop_front();
             }
 
-            // Perform FFT
             self.output_buffer.copy_from_slice(&self.input_buffer);
             self.fft.process(&mut self.output_buffer);
 
-            // Convert to magnitude spectrum
             let magnitude_spectrum = self.compute_magnitude_spectrum();
-
-            // Convert to frequency bands
             let bands = self.spectrum_to_bands(&magnitude_spectrum);
             all_bands.extend(bands);
         }
 
-        // Average overlapping results
-        let final_bands = if all_bands.is_empty() {
-            vec![0.0; self.output_bands]
-        } else {
-            let num_windows = all_bands.len() / self.output_bands;
-            let mut averaged_bands = vec![0.0; self.output_bands];
+        // No FFT window fired — caller should keep the previous result.
+        if all_bands.is_empty() {
+            return None;
+        }
 
-            for (i, &value) in all_bands.iter().enumerate() {
-                averaged_bands[i % self.output_bands] += value;
+        let num_windows = all_bands.len() / self.output_bands;
+        let mut averaged_bands = vec![0.0; self.output_bands];
+
+        for (i, &value) in all_bands.iter().enumerate() {
+            averaged_bands[i % self.output_bands] += value;
+        }
+
+        if num_windows > 0 {
+            for band in &mut averaged_bands {
+                *band /= num_windows as f32;
             }
+        }
 
-            if num_windows > 0 {
-                for band in &mut averaged_bands {
-                    *band /= num_windows as f32;
-                }
-            }
-
-            averaged_bands
-        };
-
-        // Calculate peak and RMS levels from original samples
         let (peak_level, rms_level) = self.calculate_levels(samples);
-
-        SpectrumData::new(final_bands, peak_level, rms_level)
+        Some(SpectrumData::new(averaged_bands, peak_level, rms_level))
     }
 
     /// Generate window function coefficients
@@ -436,18 +421,19 @@ mod tests {
             .map(|i| (2.0 * PI * frequency * i as f32 / sample_rate).sin())
             .collect();
 
-        let spectrum_data = analyzer.analyze(&samples);
+        let spectrum_data = analyzer
+            .analyze(&samples)
+            .expect("FFT should fire with 2048 samples");
 
         assert_eq!(spectrum_data.bands.len(), 32);
         assert!(spectrum_data.peak_level > 0.8); // Should detect significant signal
         assert!(spectrum_data.rms_level > 0.5);
 
-        // The 1kHz signal should create a peak in one of the frequency bands
         let max_band = spectrum_data
             .bands
             .iter()
             .fold(0.0f32, |acc, &x| acc.max(x));
-        assert!(max_band > 0.1); // Should have significant energy in some band
+        assert!(max_band > 0.1);
     }
 
     #[test]
@@ -455,13 +441,14 @@ mod tests {
         let mut analyzer = SpectrumAnalyzer::new(1024, 44100, 32);
         let samples = vec![0.0; 2048]; // Silence
 
-        let spectrum_data = analyzer.analyze(&samples);
+        let spectrum_data = analyzer
+            .analyze(&samples)
+            .expect("FFT should fire with 2048 samples");
 
         assert_eq!(spectrum_data.bands.len(), 32);
         assert_eq!(spectrum_data.peak_level, 0.0);
         assert_eq!(spectrum_data.rms_level, 0.0);
 
-        // All bands should be zero for silence
         for &band in &spectrum_data.bands {
             assert_eq!(band, 0.0);
         }
@@ -532,7 +519,9 @@ mod tests {
 
         // Analyzing silence after reset should give clean results
         let silence = vec![0.0; 1024];
-        let spectrum_data = analyzer.analyze(&silence);
+        let spectrum_data = analyzer
+            .analyze(&silence)
+            .expect("FFT should fire with 1024 samples");
 
         assert_eq!(spectrum_data.peak_level, 0.0);
         assert_eq!(spectrum_data.rms_level, 0.0);

--- a/crates/sonic-core/src/audio/spectrum_tap.rs
+++ b/crates/sonic-core/src/audio/spectrum_tap.rs
@@ -86,9 +86,11 @@ impl<S: Source<Item = f32>> Iterator for SpectrumTap<S> {
             self.frame_ch = 0;
 
             if self.mono_buf.len() >= HOP_MONO_SAMPLES {
-                let data = self.analyzer.analyze(&self.mono_buf);
-                // Best-effort: drop the result if no receiver is listening.
-                let _ = self.tx.send(data);
+                // Only publish when FFT actually fired; otherwise the previous
+                // real result stays in the watch channel until the next window.
+                if let Some(data) = self.analyzer.analyze(&self.mono_buf) {
+                    let _ = self.tx.send(data);
+                }
                 self.mono_buf.clear();
             }
         }


### PR DESCRIPTION
## Summary

- Binds `UiState.spectrum-bands` and `UiState.peak-level` into `VisualizerCanvas` in `app.slint`
- Replaces the hardcoded `for i in 32:` loop with `for band-value[i] in root.spectrum-data:` — fully dynamic band count (currently 64)
- Color gradient (blue → green/yellow → red) now scales proportionally with the actual band count via `spectrum-data.length / 3` thresholds
- Bars are always rendered; controller-sent zero-frames on stop produce a natural 50 ms fade-out animation via the existing `animate height`
- Placeholder ("Play music to see visualization") shown only when `spectrum-data.length == 0` (initial startup)
- `SpectrumBar` width is now `horizontal-stretch: 1` (responsive) instead of a fixed 8 px — bars fill the panel width automatically
- Per-bar peak hold implemented with a 16 ms `Timer`: jumps up instantly on new peak, decays at 0.01/frame ≈ 1.6 s from 1.0 → 0.0; indicator opacity tracks `held-peak` for a smooth visual fade
- Level meter in the stats bar shows live `peak-level` instead of the hardcoded 85%

## Related Issues
Closes #27 

## Test plan

- [x] Load and play an audio file — bars animate with frequency data in real time
- [x] Pause playback — bars animate to zero over ~50 ms (fade-out)
- [x] Resume — bars immediately reflect live FFT again
- [x] Stop — same fade-out as pause
- [x] At startup (before loading any track) — placeholder text is visible
- [x] Resize the window — bars expand/contract to fill the panel
- [x] Drag Sensitivity slider — bar heights scale accordingly (clamped to 1.0)
- [x] Peak hold indicator visible during loud passages; decays in ~1.6 s after peak drops
- [x] Level meter in the bottom stats bar tracks peak level live