### PR TITLE
feat(audio,ui): implement basic playlist management (#28)

### DIFF
--- a/app/src/app/command.rs
+++ b/app/src/app/command.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 /// Commands sent from UI to the application controller.
 #[derive(Debug)]
 pub enum Command {
-    /// Load and play an audio file
+    /// Load and play an audio file (single-file, bypasses playlist)
+    #[allow(dead_code)]
     LoadFile(PathBuf),
     /// Toggle play/pause
     TogglePlayback,
@@ -19,4 +20,24 @@ pub enum Command {
     SkipForward(f64),
     /// Skip backward by the given number of seconds (relative to current position)
     SkipBackward(f64),
+
+    // -- Playlist management ----------------------------------------------
+    /// Add one or more audio files to the playlist
+    AddTracks(Vec<PathBuf>),
+    /// Recursively scan a folder and add all audio files found
+    AddFolder(PathBuf),
+    /// Advance to the next track in the playlist
+    NextTrack,
+    /// Return to the previous track in the playlist
+    PreviousTrack,
+    /// Jump to a specific track by playlist index
+    SelectTrack(usize),
+    /// Remove the track at the given playlist index
+    RemoveTrack(usize),
+    /// Clear the entire playlist
+    ClearPlaylist,
+    /// Toggle shuffle mode
+    ToggleShuffle,
+    /// Cycle through repeat modes (None → One → All → None)
+    CycleRepeat,
 }

--- a/app/src/app/controller.rs
+++ b/app/src/app/controller.rs
@@ -1,48 +1,73 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use sonic_core::audio::player_manager::PlayerManager;
+use sonic_core::audio::playlist::{Playlist, TrackInfo, scan_folder};
 use sonic_core::{DEFAULT_BAND_COUNT, MetadataExtractor};
 
 use super::command::Command;
-use super::event::{Event, FormatInfo};
+use super::event::{Event, FormatInfo, TrackSummary};
 
-/// Application controller that processes commands and sends events.
+/// Application controller — processes UI commands and sends status/spectrum
+/// events back to the UI.
 ///
-/// Runs as a tokio task. Owns the audio PlayerManager and bridges
-/// UI commands to audio operations.
+/// Owns the `Playlist` and the `PlayerManager`. Runs as a tokio task.
 pub struct Controller {
     tx_event: mpsc::Sender<Event>,
     player: Arc<PlayerManager>,
+    playlist: Playlist,
 }
 
 impl Controller {
     pub fn new(tx_event: mpsc::Sender<Event>) -> anyhow::Result<Self> {
         let player = Arc::new(PlayerManager::new()?);
-        Ok(Self { tx_event, player })
+        Ok(Self {
+            tx_event,
+            player,
+            playlist: Playlist::new(),
+        })
     }
 
     /// Main loop: process commands and send periodic status/spectrum updates.
-    pub async fn run(self, mut rx_cmd: mpsc::Receiver<Command>) {
+    pub async fn run(mut self, mut rx_cmd: mpsc::Receiver<Command>) {
         info!("Controller started");
 
         let mut status_interval = tokio::time::interval(Duration::from_millis(100));
-        // ~60fps for spectrum; watch channel gives us the latest FFT result each tick.
         let mut spectrum_interval = tokio::time::interval(Duration::from_millis(16));
+        // Track whether we were playing on the last status tick — used to
+        // detect natural track-end (sink drained) vs explicit stop/pause.
+        let mut was_playing = false;
 
         loop {
             tokio::select! {
                 cmd = rx_cmd.recv() => {
                     match cmd {
                         Some(cmd) => self.handle_command(cmd).await,
-                        None => break, // All senders dropped (UI closed)
+                        None => break,
                     }
                 }
                 _ = status_interval.tick() => {
-                    self.send_status().await;
+                    let status = self.player.get_status().await;
+
+                    // Natural track-end detection: was playing, now stopped
+                    // (not paused), and the player still has a track loaded
+                    // (i.e., not an explicit Stop that clears current_path).
+                    let track_ended = was_playing
+                        && !status.is_playing
+                        && !status.is_paused
+                        && status.current_track.is_some();
+
+                    if track_ended {
+                        info!("Track ended naturally — advancing playlist");
+                        self.auto_advance().await;
+                    }
+
+                    was_playing = status.is_playing;
+                    self.emit_status(&status).await;
                 }
                 _ = spectrum_interval.tick() => {
                     self.send_spectrum().await;
@@ -53,35 +78,18 @@ impl Controller {
         info!("Controller stopped");
     }
 
-    async fn handle_command(&self, cmd: Command) {
+    // ------------------------------------------------------------------
+    // Command dispatch
+    // ------------------------------------------------------------------
+
+    async fn handle_command(&mut self, cmd: Command) {
         debug!("Processing command: {:?}", cmd);
 
         match cmd {
-            Command::LoadFile(path) => match self.player.load_and_play(path.clone()).await {
-                Ok(()) => {
-                    let meta_path = path.clone();
-                    let metadata = tokio::task::spawn_blocking(move || {
-                        MetadataExtractor::extract_with_fallback(&meta_path)
-                    })
-                    .await
-                    .unwrap_or_default();
-                    let _ = self
-                        .tx_event
-                        .send(Event::TrackLoaded {
-                            path,
-                            metadata: Box::new(metadata),
-                        })
-                        .await;
-                }
-                Err(e) => {
-                    let error = e.to_string();
-                    error!("Failed to load track: {}", error);
-                    let _ = self
-                        .tx_event
-                        .send(Event::TrackLoadFailed { path, error })
-                        .await;
-                }
-            },
+            Command::LoadFile(path) => {
+                self.load_and_emit(path).await;
+            }
+
             Command::TogglePlayback => {
                 let status = self.player.get_status().await;
                 let result = if status.is_playing {
@@ -93,66 +101,217 @@ impl Controller {
                     let _ = self.tx_event.send(Event::Error(e.to_string())).await;
                 }
             }
+
             Command::Stop => {
                 if let Err(e) = self.player.stop().await {
                     let _ = self.tx_event.send(Event::Error(e.to_string())).await;
                 }
             }
+
             Command::SetVolume(volume) => {
                 if let Err(e) = self.player.set_volume(volume).await {
                     let _ = self.tx_event.send(Event::Error(e.to_string())).await;
                 }
             }
+
             Command::Seek(position) => match self.player.seek(position).await {
                 Ok(actual) => {
                     debug!("Seeked to {:?} (requested {:?})", actual, position);
-                    self.send_status().await;
                 }
                 Err(e) => {
                     let _ = self.tx_event.send(Event::Error(e.to_string())).await;
                 }
             },
+
             Command::SkipForward(seconds) => {
                 let status = self.player.get_status().await;
-                let offset = Duration::from_secs_f64(seconds);
-                let target = status.position.saturating_add(offset);
-                // Clamp to track duration when known.
-                let target = match status.duration {
-                    Some(d) => target.min(d),
-                    None => target,
+                let target = {
+                    let offset = Duration::from_secs_f64(seconds);
+                    let t = status.position.saturating_add(offset);
+                    status.duration.map_or(t, |d| t.min(d))
                 };
                 info!("Skip forward {}s → {:?}", seconds, target);
-                match self.player.seek(target).await {
-                    Ok(actual) => {
-                        debug!("Skip forward seeked to {:?}", actual);
-                        self.send_status().await;
-                    }
-                    Err(e) => {
-                        let _ = self.tx_event.send(Event::Error(e.to_string())).await;
-                    }
+                if let Err(e) = self.player.seek(target).await {
+                    let _ = self.tx_event.send(Event::Error(e.to_string())).await;
                 }
             }
+
             Command::SkipBackward(seconds) => {
                 let status = self.player.get_status().await;
-                let offset = Duration::from_secs_f64(seconds);
-                let target = status.position.saturating_sub(offset);
+                let target = status
+                    .position
+                    .saturating_sub(Duration::from_secs_f64(seconds));
                 info!("Skip backward {}s → {:?}", seconds, target);
-                match self.player.seek(target).await {
-                    Ok(actual) => {
-                        debug!("Skip backward seeked to {:?}", actual);
-                        self.send_status().await;
+                if let Err(e) = self.player.seek(target).await {
+                    let _ = self.tx_event.send(Event::Error(e.to_string())).await;
+                }
+            }
+
+            // -- Playlist commands -----------------------------------------
+            Command::AddTracks(paths) => {
+                let infos = extract_track_infos(paths).await;
+                self.playlist.add_tracks(infos);
+                self.emit_playlist_updated().await;
+
+                // Auto-start if nothing is playing and this is the first batch.
+                if !self.player.get_status().await.is_playing
+                    && self.playlist.current_index().is_none()
+                {
+                    self.playlist.select(0);
+                    if let Some(path) = self.playlist.current().map(|t| t.path.clone()) {
+                        self.load_and_emit(path).await;
                     }
-                    Err(e) => {
-                        let _ = self.tx_event.send(Event::Error(e.to_string())).await;
+                    self.emit_playlist_updated().await;
+                }
+            }
+
+            Command::AddFolder(folder) => {
+                let paths = tokio::task::spawn_blocking(move || scan_folder(&folder))
+                    .await
+                    .unwrap_or_default();
+                if paths.is_empty() {
+                    warn!("No audio files found in selected folder");
+                    return;
+                }
+                let infos = extract_track_infos(paths).await;
+                self.playlist.add_tracks(infos);
+                self.emit_playlist_updated().await;
+
+                // Auto-start if idle.
+                if !self.player.get_status().await.is_playing
+                    && self.playlist.current_index().is_none()
+                {
+                    self.playlist.select(0);
+                    if let Some(path) = self.playlist.current().map(|t| t.path.clone()) {
+                        self.load_and_emit(path).await;
                     }
+                    self.emit_playlist_updated().await;
+                }
+            }
+
+            Command::NextTrack => {
+                let next = self.playlist.next().map(|t| t.path.clone());
+                if let Some(path) = next {
+                    self.load_and_emit(path).await;
+                    self.emit_playlist_updated().await;
+                }
+            }
+
+            Command::PreviousTrack => {
+                let prev = self.playlist.previous().map(|t| t.path.clone());
+                if let Some(path) = prev {
+                    self.load_and_emit(path).await;
+                    self.emit_playlist_updated().await;
+                }
+            }
+
+            Command::SelectTrack(index) => {
+                let selected = self.playlist.select(index).map(|t| t.path.clone());
+                if let Some(path) = selected {
+                    self.load_and_emit(path).await;
+                    self.emit_playlist_updated().await;
+                }
+            }
+
+            Command::RemoveTrack(index) => {
+                self.playlist.remove(index);
+                self.emit_playlist_updated().await;
+            }
+
+            Command::ClearPlaylist => {
+                self.playlist.clear();
+                let _ = self.player.stop().await;
+                self.emit_playlist_updated().await;
+            }
+
+            Command::ToggleShuffle => {
+                self.playlist.toggle_shuffle();
+                self.emit_playlist_updated().await;
+            }
+
+            Command::CycleRepeat => {
+                self.playlist.cycle_repeat();
+                self.emit_playlist_updated().await;
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    /// Called when the sink drains naturally — advance the playlist and load.
+    async fn auto_advance(&mut self) {
+        let next_path = self.playlist.next().map(|t| t.path.clone());
+        match next_path {
+            Some(path) => {
+                self.load_and_emit(path).await;
+                self.emit_playlist_updated().await;
+            }
+            None => {
+                // End of playlist — stop and clear the player's current_track
+                // so subsequent status polls show idle state correctly.
+                if let Err(e) = self.player.stop().await {
+                    error!("Error stopping after playlist end: {e}");
                 }
             }
         }
     }
 
+    /// Load a file, start playback, extract metadata, and emit events.
+    async fn load_and_emit(&self, path: PathBuf) {
+        match self.player.load_and_play(path.clone()).await {
+            Ok(()) => {
+                let meta_path = path.clone();
+                let metadata = tokio::task::spawn_blocking(move || {
+                    MetadataExtractor::extract_with_fallback(&meta_path)
+                })
+                .await
+                .unwrap_or_default();
+
+                let _ = self
+                    .tx_event
+                    .send(Event::TrackLoaded {
+                        path,
+                        metadata: Box::new(metadata),
+                    })
+                    .await;
+            }
+            Err(e) => {
+                let error = e.to_string();
+                error!("Failed to load track '{}': {error}", path.display());
+                let _ = self
+                    .tx_event
+                    .send(Event::TrackLoadFailed { path, error })
+                    .await;
+            }
+        }
+    }
+
+    async fn emit_playlist_updated(&self) {
+        let tracks: Vec<TrackSummary> = self
+            .playlist
+            .tracks()
+            .iter()
+            .map(|t| TrackSummary {
+                title: t.title.clone(),
+                artist: t.artist.clone(),
+                duration: t.duration,
+            })
+            .collect();
+
+        let _ = self
+            .tx_event
+            .send(Event::PlaylistUpdated {
+                current_index: self.playlist.current_index(),
+                total_duration: self.playlist.total_duration(),
+                tracks,
+            })
+            .await;
+    }
+
     async fn send_spectrum(&self) {
-        use std::time::Duration as StdDuration;
-        let stale_threshold = StdDuration::from_millis(200);
+        let stale_threshold = Duration::from_millis(200);
 
         match self.player.get_spectrum().await {
             Some(data) if data.is_recent(stale_threshold) => {
@@ -165,7 +324,6 @@ impl Controller {
                     .await;
             }
             Some(data) => {
-                // Data is stale (playback stopped); fade to zero.
                 let n = data.bands.len();
                 let _ = self
                     .tx_event
@@ -176,7 +334,6 @@ impl Controller {
                     .await;
             }
             None => {
-                // No track loaded.
                 let _ = self
                     .tx_event
                     .send(Event::SpectrumUpdated {
@@ -188,9 +345,7 @@ impl Controller {
         }
     }
 
-    async fn send_status(&self) {
-        let status = self.player.get_status().await;
-
+    async fn emit_status(&self, status: &sonic_core::PlayerStatus) {
         let format = status.format.as_ref().map(|f| FormatInfo {
             sample_rate: f.sample_rate,
             channels: f.channels,
@@ -205,9 +360,28 @@ impl Controller {
                 volume: status.volume,
                 position: status.position,
                 duration: status.duration,
-                track_path: status.current_track,
+                track_path: status.current_track.clone(),
                 format,
             })
             .await;
     }
+}
+
+// ------------------------------------------------------------------
+// Free functions
+// ------------------------------------------------------------------
+
+/// Extract metadata for a batch of paths in a blocking task.
+async fn extract_track_infos(paths: Vec<PathBuf>) -> Vec<TrackInfo> {
+    tokio::task::spawn_blocking(move || {
+        paths
+            .into_iter()
+            .map(|path| {
+                let meta = MetadataExtractor::extract_with_fallback(&path);
+                TrackInfo::from_path(path).with_metadata(meta.title, meta.artist, meta.duration)
+            })
+            .collect()
+    })
+    .await
+    .unwrap_or_default()
 }

--- a/app/src/app/event.rs
+++ b/app/src/app/event.rs
@@ -25,8 +25,23 @@ pub enum Event {
     TrackLoadFailed { path: PathBuf, error: String },
     /// Real-time spectrum analysis update (~60 fps)
     SpectrumUpdated { bands: Vec<f32>, peak: f32 },
+    /// Playlist contents changed (tracks added/removed/reordered) or current
+    /// index changed (next/prev/select).
+    PlaylistUpdated {
+        tracks: Vec<TrackSummary>,
+        current_index: Option<usize>,
+        total_duration: Duration,
+    },
     /// General error
     Error(String),
+}
+
+/// Lightweight track description for playlist display.
+#[derive(Debug, Clone)]
+pub struct TrackSummary {
+    pub title: String,
+    pub artist: String,
+    pub duration: Option<Duration>,
 }
 
 /// Audio format information for display

--- a/app/src/ui/app.slint
+++ b/app/src/ui/app.slint
@@ -1,5 +1,5 @@
 import { Button, HorizontalBox, VerticalBox } from "std-widgets.slint";
-import { ColorTheme } from "components/common.slint";
+import { ColorTheme, PlaylistTrack } from "components/common.slint";
 import { PlayerControls } from "components/player_controls.slint";
 import { VisualizerCanvas } from "components/visualizer_canvas.slint";
 import { NowPlayingInfo } from "components/track_info.slint";
@@ -47,6 +47,7 @@ export global UiState {
     in-out property <int>  current-track-index: -1;
     in-out property <int>  total-tracks: 0;
     in-out property <string> total-duration: "00:00";
+    in-out property <[PlaylistTrack]> playlist-items: [];
 
     // -- Transport callbacks (UI -> Rust) ---------------------------------
     callback play-pause-clicked();
@@ -108,16 +109,15 @@ export component AppWindow inherits Window {
                 is-playing: UiState.is-playing;
                 total-tracks: UiState.total-tracks;
                 total-duration: UiState.total-duration;
+                playlist-items: UiState.playlist-items;
 
-                toggle-collapsed   => { UiState.playlist-toggle-collapsed(); }
-                track-selected(i)  => { UiState.playlist-track-selected(i); }
-                track-removed(i)   => { UiState.playlist-track-removed(i); }
-                clear-playlist     => { UiState.playlist-clear(); }
-                load-folder        => { UiState.playlist-load-folder(); }
-                load-files         => { UiState.playlist-load-files(); }
-                save-playlist      => { UiState.playlist-save(); }
-                folder-selected(p) => { UiState.playlist-folder-selected(p); }
-                file-selected(p)   => { UiState.playlist-file-selected(p); }
+                toggle-collapsed  => { UiState.playlist-toggle-collapsed(); }
+                track-selected(i) => { UiState.playlist-track-selected(i); }
+                track-removed(i)  => { UiState.playlist-track-removed(i); }
+                clear-playlist    => { UiState.playlist-clear(); }
+                load-folder       => { UiState.playlist-load-folder(); }
+                load-files        => { UiState.playlist-load-files(); }
+                save-playlist     => { UiState.playlist-save(); }
             }
 
             // Center panel - Visualizer

--- a/app/src/ui/components/common.slint
+++ b/app/src/ui/components/common.slint
@@ -56,6 +56,13 @@ export global ColorTheme {
     in-out property <duration> animation-slow: 400ms;
 }
 
+/// A single playlist entry passed from Rust to Slint.
+export struct PlaylistTrack {
+    title: string,
+    artist: string,
+    duration: string,
+}
+
 // 共通ボタンスタイル
 export component StyledButton inherits Rectangle {
     in property <string> text;

--- a/app/src/ui/components/playlist_view.slint
+++ b/app/src/ui/components/playlist_view.slint
@@ -1,5 +1,5 @@
 import { Button, ScrollView, ListView, VerticalBox, HorizontalBox, LineEdit } from "std-widgets.slint";
-import { ColorTheme, StyledButton, GlowText, Panel } from "common.slint";
+import { ColorTheme, StyledButton, GlowText, Panel, PlaylistTrack } from "common.slint";
 
 // プレイリストアイテム
 component PlaylistItem inherits Rectangle {
@@ -107,56 +107,6 @@ component PlaylistItem inherits Rectangle {
     }
 }
 
-// フォルダブラウザー
-component FolderBrowser inherits VerticalBox {
-    in property <[string]> folder-contents: [];
-    callback folder-selected(string);
-    callback file-selected(string);
-    
-    spacing: ColorTheme.spacing-small;
-    
-    GlowText {
-        text: "Browse Folders";
-        color: ColorTheme.text-secondary;
-        font-size: ColorTheme.font-size-small;
-        font-weight: 700;
-    }
-    
-    ScrollView {
-        height: 150px;
-        
-        VerticalBox {
-            spacing: 2px;
-            
-            for item in folder-contents: Rectangle {
-                height: 30px;
-                background: mouse-area.has-hover ? ColorTheme.surface-variant : transparent;
-                border-radius: ColorTheme.border-radius-small;
-                
-                mouse-area := TouchArea {
-                    clicked => {
-                        // 簡易的なフォルダ判定（最初の文字）
-                        root.file-selected(item);
-                    }
-                }
-                
-                HorizontalBox {
-                    padding: 8px;
-                    spacing: ColorTheme.spacing-small;
-                    
-                    GlowText {
-                        text: item;
-                        color: ColorTheme.text-secondary;
-                        font-size: ColorTheme.font-size-small;
-                        vertical-alignment: center;
-                        overflow: elide;
-                    }
-                }
-            }
-        }
-    }
-}
-
 // プレイリストビュー
 export component PlaylistView inherits Panel {
     in-out property <bool> is-collapsed: false;
@@ -165,25 +115,7 @@ export component PlaylistView inherits Panel {
     in-out property <string> total-duration: "0:00";
     in-out property <int> current-track-index: -1;
     in-out property <bool> is-playing: false;
-    
-    // プレイリスト項目（例のデータ）
-    in-out property <[{title: string, artist: string, duration: string}]> playlist-items: [
-        {title: "Sample Track 1", artist: "Artist 1", duration: "3:45"},
-        {title: "Sample Track 2", artist: "Artist 2", duration: "4:12"},
-        {title: "Sample Track 3", artist: "Artist 3", duration: "2:58"},
-        {title: "Sample Track 4", artist: "Artist 4", duration: "5:23"},
-        {title: "Sample Track 5", artist: "Artist 5", duration: "3:31"},
-    ];
-    
-    // フォルダブラウジング用
-    in-out property <[string]> folder-contents: [
-        "📁 Music",
-        "📁 Albums", 
-        "📁 Artists",
-        "🎵 demo.mp3",
-        "🎵 sample.flac",
-        "🎵 test.wav"
-    ];
+    in-out property <[PlaylistTrack]> playlist-items: [];
     
     // コールバック
     callback toggle-collapsed();
@@ -349,17 +281,6 @@ export component PlaylistView inherits Panel {
                 }
             }
             
-            Rectangle {
-                height: 1px;
-                background: ColorTheme.border;
-            }
-            
-            // フォルダブラウザー
-            FolderBrowser {
-                folder-contents: root.folder-contents;
-                folder-selected(path) => { root.folder-selected(path); }
-                file-selected(path) => { root.file-selected(path); }
-            }
         }
         
         if root.is-collapsed: VerticalBox {

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
-use slint::ComponentHandle;
+use slint::{ComponentHandle, Global};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
 use crate::app::{Command, Event};
-use crate::{AppWindow, UiState};
+use crate::{AppWindow, PlaylistTrack, UiState};
 
 /// Main UI wrapper. Creates the Slint window, registers callbacks,
 /// and spawns the event handler task.
@@ -25,7 +25,7 @@ impl Ui {
         Self::register_file_callbacks(&ui, &tx_cmd);
         Self::register_volume_callbacks(&ui, &tx_cmd);
         Self::register_visualizer_callbacks(&ui);
-        Self::register_playlist_callbacks(&ui);
+        Self::register_playlist_callbacks(&ui, &tx_cmd);
         Self::spawn_event_handler(&window, rx_event);
 
         info!("UI initialized");
@@ -80,12 +80,49 @@ impl Ui {
             }
         });
 
+        ui.on_next_track({
+            let tx = tx_cmd.clone();
+            move || {
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::NextTrack).await;
+                });
+            }
+        });
+
+        ui.on_previous_track({
+            let tx = tx_cmd.clone();
+            move || {
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::PreviousTrack).await;
+                });
+            }
+        });
+
+        ui.on_shuffle_toggled({
+            let tx = tx_cmd.clone();
+            move || {
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::ToggleShuffle).await;
+                });
+            }
+        });
+
+        ui.on_repeat_toggled({
+            let tx = tx_cmd.clone();
+            move || {
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::CycleRepeat).await;
+                });
+            }
+        });
+
         ui.on_seek(|_position| {
             debug!("Seek requested (not yet implemented)");
         });
-
-        ui.on_next_track(|| debug!("Next track (not yet implemented)"));
-        ui.on_previous_track(|| debug!("Previous track (not yet implemented)"));
     }
 
     // -- File callbacks ---------------------------------------------------
@@ -94,17 +131,17 @@ impl Ui {
         ui.on_load_track_clicked({
             let tx = tx_cmd.clone();
             move || {
-                let path = rfd::FileDialog::new()
+                let paths = rfd::FileDialog::new()
                     .add_filter("Audio Files", &["mp3", "flac", "wav", "ogg", "m4a", "aac"])
                     .add_filter("All Files", &["*"])
-                    .set_title("Select Audio File")
-                    .pick_file();
+                    .set_title("Select Audio File(s)")
+                    .pick_files();
 
-                if let Some(path) = path {
-                    info!("Selected file: {}", path.display());
+                if let Some(paths) = paths {
+                    info!("Selected {} file(s) via load-track", paths.len());
                     let tx = tx.clone();
                     tokio::spawn(async move {
-                        let _ = tx.send(Command::LoadFile(path)).await;
+                        let _ = tx.send(Command::AddTracks(paths)).await;
                     });
                 }
             }
@@ -135,18 +172,86 @@ impl Ui {
         ui.on_fullscreen_toggled(|| debug!("Fullscreen toggled"));
     }
 
-    // -- Playlist callbacks (stubs) ---------------------------------------
+    // -- Playlist callbacks -----------------------------------------------
 
-    fn register_playlist_callbacks(ui: &UiState) {
-        ui.on_shuffle_toggled(|| debug!("Shuffle toggled"));
-        ui.on_repeat_toggled(|| debug!("Repeat toggled"));
-        ui.on_playlist_toggle_collapsed(|| debug!("Playlist toggle collapsed"));
-        ui.on_playlist_track_selected(|i| debug!("Playlist track selected: {}", i));
-        ui.on_playlist_track_removed(|i| debug!("Playlist track removed: {}", i));
-        ui.on_playlist_load_files(|| debug!("Playlist load files"));
-        ui.on_playlist_load_folder(|| debug!("Playlist load folder"));
-        ui.on_playlist_save(|| debug!("Playlist save"));
-        ui.on_playlist_clear(|| debug!("Playlist clear"));
+    fn register_playlist_callbacks(ui: &UiState, tx_cmd: &mpsc::Sender<Command>) {
+        ui.on_playlist_toggle_collapsed({
+            let ui_weak = ui.as_weak();
+            move || {
+                if let Some(ui) = ui_weak.upgrade() {
+                    let collapsed: bool = ui.get_playlist_collapsed();
+                    ui.set_playlist_collapsed(!collapsed);
+                }
+            }
+        });
+
+        ui.on_playlist_track_selected({
+            let tx = tx_cmd.clone();
+            move |i| {
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::SelectTrack(i as usize)).await;
+                });
+            }
+        });
+
+        ui.on_playlist_track_removed({
+            let tx = tx_cmd.clone();
+            move |i| {
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::RemoveTrack(i as usize)).await;
+                });
+            }
+        });
+
+        ui.on_playlist_clear({
+            let tx = tx_cmd.clone();
+            move || {
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(Command::ClearPlaylist).await;
+                });
+            }
+        });
+
+        ui.on_playlist_load_files({
+            let tx = tx_cmd.clone();
+            move || {
+                let paths = rfd::FileDialog::new()
+                    .add_filter("Audio Files", &["mp3", "flac", "wav", "ogg", "m4a", "aac"])
+                    .add_filter("All Files", &["*"])
+                    .set_title("Add Audio Files")
+                    .pick_files();
+
+                if let Some(paths) = paths {
+                    info!("Adding {} file(s) to playlist", paths.len());
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        let _ = tx.send(Command::AddTracks(paths)).await;
+                    });
+                }
+            }
+        });
+
+        ui.on_playlist_load_folder({
+            let tx = tx_cmd.clone();
+            move || {
+                let folder = rfd::FileDialog::new()
+                    .set_title("Add Music Folder")
+                    .pick_folder();
+
+                if let Some(folder) = folder {
+                    info!("Adding folder to playlist: {}", folder.display());
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        let _ = tx.send(Command::AddFolder(folder)).await;
+                    });
+                }
+            }
+        });
+
+        ui.on_playlist_save(|| debug!("Playlist save (not yet implemented)"));
         ui.on_playlist_folder_selected(|p| debug!("Playlist folder: {}", p));
         ui.on_playlist_file_selected(|p| debug!("Playlist file: {}", p));
     }
@@ -215,7 +320,6 @@ impl Ui {
                     }
                     None => {
                         ui.set_current_track("No track loaded".into());
-                        // Clear metadata when no track is loaded.
                         ui.set_track_title("".into());
                         ui.set_track_artist("".into());
                         ui.set_track_album("".into());
@@ -255,6 +359,26 @@ impl Ui {
                 let model = slint::ModelRc::new(slint::VecModel::from(bands));
                 ui.set_spectrum_bands(model);
                 ui.set_peak_level(peak);
+            }
+
+            Event::PlaylistUpdated {
+                tracks,
+                current_index,
+                total_duration,
+            } => {
+                let items: Vec<PlaylistTrack> = tracks
+                    .iter()
+                    .map(|t| PlaylistTrack {
+                        title: t.title.clone().into(),
+                        artist: t.artist.clone().into(),
+                        duration: t.duration.map(format_duration).unwrap_or_default().into(),
+                    })
+                    .collect();
+                let model = slint::ModelRc::new(slint::VecModel::from(items));
+                ui.set_playlist_items(model);
+                ui.set_total_tracks(tracks.len() as i32);
+                ui.set_current_track_index(current_index.map(|i| i as i32).unwrap_or(-1));
+                ui.set_total_duration(format_duration(total_duration).into());
             }
 
             Event::Error(msg) => {

--- a/crates/sonic-core/src/audio/mod.rs
+++ b/crates/sonic-core/src/audio/mod.rs
@@ -5,6 +5,7 @@ pub mod decoder;
 pub mod metadata;
 pub mod player;
 pub mod player_manager;
+pub mod playlist;
 pub mod spectrum_tap;
 pub mod traits;
 
@@ -12,5 +13,6 @@ pub use analysis::{SpectrumAnalyzer, SpectrumData};
 pub use decoder::{AudioBuffer, AudioDecoder, AudioFormatInfo, SymphoniaDecoder};
 pub use metadata::{MetadataExtractor, TrackMetadata};
 pub use player_manager::{PlayerManager, PlayerStatus};
+pub use playlist::{AUDIO_EXTENSIONS, Playlist, RepeatMode, TrackInfo, scan_folder};
 pub use spectrum_tap::DEFAULT_BAND_COUNT;
 pub use traits::{AudioFormat, AudioFormatType};

--- a/crates/sonic-core/src/audio/playlist.rs
+++ b/crates/sonic-core/src/audio/playlist.rs
@@ -1,0 +1,486 @@
+//! Playlist management — ordered track list with shuffle and repeat support.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Minimum information needed to represent a track in the playlist.
+#[derive(Debug, Clone)]
+pub struct TrackInfo {
+    pub path: PathBuf,
+    pub title: String,
+    pub artist: String,
+    pub duration: Option<Duration>,
+}
+
+impl TrackInfo {
+    /// Build a `TrackInfo` from a path, using the file stem as the fallback title.
+    pub fn from_path(path: PathBuf) -> Self {
+        let title = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("Unknown")
+            .to_string();
+        Self {
+            path,
+            title,
+            artist: String::new(),
+            duration: None,
+        }
+    }
+
+    /// Overlay metadata onto a path-only `TrackInfo`.
+    pub fn with_metadata(
+        mut self,
+        title: Option<String>,
+        artist: Option<String>,
+        duration: Option<Duration>,
+    ) -> Self {
+        if let Some(t) = title.filter(|t| !t.is_empty()) {
+            self.title = t;
+        }
+        if let Some(a) = artist {
+            self.artist = a;
+        }
+        self.duration = duration;
+        self
+    }
+}
+
+/// Repeat behaviour for the playlist.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum RepeatMode {
+    #[default]
+    None,
+    One,
+    All,
+}
+
+impl RepeatMode {
+    /// Advance to the next mode in the cycle: None → One → All → None.
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::None => Self::One,
+            Self::One => Self::All,
+            Self::All => Self::None,
+        }
+    }
+}
+
+/// Ordered track list with optional shuffle and repeat.
+pub struct Playlist {
+    tracks: Vec<TrackInfo>,
+    current_index: Option<usize>,
+    /// Permuted indices used when shuffle is active.
+    shuffle_order: Vec<usize>,
+    /// Position within `shuffle_order` for the currently playing track.
+    shuffle_pos: usize,
+    pub repeat_mode: RepeatMode,
+    pub shuffle_enabled: bool,
+}
+
+impl Default for Playlist {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Playlist {
+    pub fn new() -> Self {
+        Self {
+            tracks: Vec::new(),
+            current_index: None,
+            shuffle_order: Vec::new(),
+            shuffle_pos: 0,
+            repeat_mode: RepeatMode::None,
+            shuffle_enabled: false,
+        }
+    }
+
+    /// Append tracks. Shuffle order is extended if shuffle is currently active.
+    pub fn add_tracks(&mut self, mut infos: Vec<TrackInfo>) {
+        let start = self.tracks.len();
+        self.tracks.append(&mut infos);
+        if self.shuffle_enabled {
+            let new_indices: Vec<usize> = (start..self.tracks.len()).collect();
+            self.shuffle_order.extend(new_indices);
+        }
+    }
+
+    /// Advance to the next track, applying repeat/shuffle logic.
+    ///
+    /// Returns `None` when the end of the playlist is reached and repeat is
+    /// not set to `All`.
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Option<&TrackInfo> {
+        if self.tracks.is_empty() {
+            return None;
+        }
+        if self.repeat_mode == RepeatMode::One {
+            return self.current();
+        }
+
+        if self.shuffle_enabled {
+            let next_pos = self.shuffle_pos + 1;
+            if next_pos >= self.shuffle_order.len() {
+                if self.repeat_mode == RepeatMode::All {
+                    self.shuffle_pos = 0;
+                } else {
+                    self.current_index = None;
+                    return None;
+                }
+            } else {
+                self.shuffle_pos = next_pos;
+            }
+            let idx = self.shuffle_order[self.shuffle_pos];
+            self.current_index = Some(idx);
+        } else {
+            let next = self.current_index.map(|i| i + 1).unwrap_or(0);
+            if next >= self.tracks.len() {
+                if self.repeat_mode == RepeatMode::All {
+                    self.current_index = Some(0);
+                } else {
+                    self.current_index = None;
+                    return None;
+                }
+            } else {
+                self.current_index = Some(next);
+            }
+        }
+
+        self.current()
+    }
+
+    /// Move to the previous track, applying repeat/shuffle logic.
+    pub fn previous(&mut self) -> Option<&TrackInfo> {
+        if self.tracks.is_empty() {
+            return None;
+        }
+        if self.repeat_mode == RepeatMode::One {
+            return self.current();
+        }
+
+        if self.shuffle_enabled {
+            if self.shuffle_pos == 0 {
+                if self.repeat_mode == RepeatMode::All {
+                    self.shuffle_pos = self.shuffle_order.len().saturating_sub(1);
+                }
+                // else: stay at first track
+            } else {
+                self.shuffle_pos -= 1;
+            }
+            let idx = self
+                .shuffle_order
+                .get(self.shuffle_pos)
+                .copied()
+                .unwrap_or(0);
+            self.current_index = Some(idx);
+        } else {
+            let prev = match self.current_index {
+                None | Some(0) => {
+                    if self.repeat_mode == RepeatMode::All {
+                        self.tracks.len().saturating_sub(1)
+                    } else {
+                        0
+                    }
+                }
+                Some(i) => i - 1,
+            };
+            self.current_index = Some(prev);
+        }
+
+        self.current()
+    }
+
+    /// Jump directly to a track by index.
+    pub fn select(&mut self, index: usize) -> Option<&TrackInfo> {
+        if index >= self.tracks.len() {
+            return None;
+        }
+        self.current_index = Some(index);
+        if self.shuffle_enabled
+            && let Some(pos) = self.shuffle_order.iter().position(|&i| i == index)
+        {
+            self.shuffle_pos = pos;
+        }
+        self.tracks.get(index)
+    }
+
+    /// Remove the track at `index`. Adjusts `current_index` accordingly.
+    pub fn remove(&mut self, index: usize) {
+        if index >= self.tracks.len() {
+            return;
+        }
+        self.tracks.remove(index);
+
+        self.current_index = match self.current_index {
+            Some(cur) if cur == index => {
+                if self.tracks.is_empty() {
+                    None
+                } else {
+                    Some(cur.min(self.tracks.len() - 1))
+                }
+            }
+            Some(cur) if cur > index => Some(cur - 1),
+            other => other,
+        };
+
+        if self.shuffle_enabled {
+            self.rebuild_shuffle();
+        }
+    }
+
+    /// Remove all tracks and reset state.
+    pub fn clear(&mut self) {
+        self.tracks.clear();
+        self.current_index = None;
+        self.shuffle_order.clear();
+        self.shuffle_pos = 0;
+    }
+
+    /// Toggle shuffle mode on/off, rebuilding the shuffle order when enabling.
+    pub fn toggle_shuffle(&mut self) {
+        self.shuffle_enabled = !self.shuffle_enabled;
+        if self.shuffle_enabled {
+            self.rebuild_shuffle();
+        }
+    }
+
+    /// Advance the repeat mode through the cycle: None → One → All → None.
+    pub fn cycle_repeat(&mut self) {
+        self.repeat_mode = self.repeat_mode.cycle();
+    }
+
+    /// Return the currently selected track, if any.
+    pub fn current(&self) -> Option<&TrackInfo> {
+        self.current_index.and_then(|i| self.tracks.get(i))
+    }
+
+    pub fn tracks(&self) -> &[TrackInfo] {
+        &self.tracks
+    }
+
+    pub fn current_index(&self) -> Option<usize> {
+        self.current_index
+    }
+
+    /// Sum of all known track durations.
+    pub fn total_duration(&self) -> Duration {
+        self.tracks
+            .iter()
+            .filter_map(|t| t.duration)
+            .fold(Duration::ZERO, |acc, d| acc + d)
+    }
+
+    pub fn len(&self) -> usize {
+        self.tracks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tracks.is_empty()
+    }
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    /// Rebuild the shuffle permutation, placing the current track first.
+    fn rebuild_shuffle(&mut self) {
+        let n = self.tracks.len();
+        self.shuffle_order = (0..n).collect();
+        fisher_yates_shuffle(&mut self.shuffle_order);
+
+        // Keep the currently playing track at position 0 of the shuffle order
+        // so it does not repeat immediately in the next round.
+        if let Some(cur) = self.current_index {
+            if let Some(pos) = self.shuffle_order.iter().position(|&i| i == cur) {
+                self.shuffle_order.swap(0, pos);
+            }
+            self.shuffle_pos = 0;
+        }
+    }
+}
+
+/// Accepted audio file extensions for folder scanning.
+pub const AUDIO_EXTENSIONS: &[&str] = &["mp3", "flac", "wav", "ogg", "m4a", "aac"];
+
+/// Recursively collect all audio files under `dir`.
+pub fn scan_folder(dir: &Path) -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    scan_folder_inner(dir, &mut results);
+    results.sort();
+    results
+}
+
+fn scan_folder_inner(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_folder_inner(&path, out);
+        } else if let Some(ext) = path.extension().and_then(|e| e.to_str())
+            && AUDIO_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str())
+        {
+            out.push(path);
+        }
+    }
+}
+
+/// Fisher-Yates shuffle using a simple time-seeded LCG (no external crate).
+fn fisher_yates_shuffle(v: &mut [usize]) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let seed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64 ^ (d.as_secs() << 32))
+        .unwrap_or(0xdeadbeef_cafebabe);
+
+    // Knuth multiplicative hash LCG
+    let mut rng = seed
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+
+    let n = v.len();
+    for i in (1..n).rev() {
+        rng = rng
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let j = (rng >> 33) as usize % (i + 1);
+        v.swap(i, j);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_track(n: usize) -> TrackInfo {
+        TrackInfo {
+            path: PathBuf::from(format!("/music/track_{n:02}.mp3")),
+            title: format!("Track {n}"),
+            artist: "Artist".into(),
+            duration: Some(Duration::from_secs(180)),
+        }
+    }
+
+    fn playlist_of(n: usize) -> Playlist {
+        let mut p = Playlist::new();
+        p.add_tracks((1..=n).map(make_track).collect());
+        p
+    }
+
+    #[test]
+    fn add_and_select() {
+        let mut p = playlist_of(3);
+        assert_eq!(p.len(), 3);
+        let t = p.select(1).expect("index 1 should exist");
+        assert_eq!(t.title, "Track 2");
+        assert_eq!(p.current_index(), Some(1));
+    }
+
+    #[test]
+    fn next_sequential() {
+        let mut p = playlist_of(3);
+        p.select(0);
+        assert_eq!(p.next().map(|t| t.title.as_str()), Some("Track 2"));
+        assert_eq!(p.next().map(|t| t.title.as_str()), Some("Track 3"));
+        assert!(p.next().is_none()); // end of list, no repeat
+    }
+
+    #[test]
+    fn next_repeat_all() {
+        let mut p = playlist_of(3);
+        p.repeat_mode = RepeatMode::All;
+        p.select(2);
+        assert_eq!(p.next().map(|t| t.title.as_str()), Some("Track 1"));
+    }
+
+    #[test]
+    fn next_repeat_one() {
+        let mut p = playlist_of(3);
+        p.repeat_mode = RepeatMode::One;
+        p.select(1);
+        assert_eq!(p.next().map(|t| t.title.as_str()), Some("Track 2"));
+        assert_eq!(p.next().map(|t| t.title.as_str()), Some("Track 2"));
+    }
+
+    #[test]
+    fn previous_sequential() {
+        let mut p = playlist_of(3);
+        p.select(2);
+        assert_eq!(p.previous().map(|t| t.title.as_str()), Some("Track 2"));
+        assert_eq!(p.previous().map(|t| t.title.as_str()), Some("Track 1"));
+        // At first track without repeat — stays at 0
+        assert_eq!(p.previous().map(|t| t.title.as_str()), Some("Track 1"));
+    }
+
+    #[test]
+    fn remove_current_track() {
+        let mut p = playlist_of(3);
+        p.select(1);
+        p.remove(1);
+        assert_eq!(p.len(), 2);
+        // current_index clamped to new length
+        assert!(p.current_index() <= Some(1));
+    }
+
+    #[test]
+    fn remove_track_before_current() {
+        let mut p = playlist_of(3);
+        p.select(2);
+        p.remove(0);
+        assert_eq!(p.current_index(), Some(1)); // index shifted down
+    }
+
+    #[test]
+    fn clear_resets_state() {
+        let mut p = playlist_of(3);
+        p.select(1);
+        p.clear();
+        assert!(p.is_empty());
+        assert_eq!(p.current_index(), None);
+    }
+
+    #[test]
+    fn total_duration() {
+        let p = playlist_of(3);
+        assert_eq!(p.total_duration(), Duration::from_secs(540)); // 3 * 180
+    }
+
+    #[test]
+    fn shuffle_covers_all_tracks() {
+        let mut p = playlist_of(5);
+        p.select(0);
+        p.toggle_shuffle();
+        assert!(p.shuffle_enabled);
+        assert_eq!(p.shuffle_order.len(), 5);
+
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(p.current_index().unwrap());
+        for _ in 0..4 {
+            p.next();
+            if let Some(idx) = p.current_index() {
+                visited.insert(idx);
+            }
+        }
+        assert_eq!(visited.len(), 5, "all 5 tracks should be visited");
+    }
+
+    #[test]
+    fn scan_folder_empty_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let found = scan_folder(tmp.path());
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn scan_folder_finds_audio_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Create dummy audio files.
+        for name in &["a.mp3", "b.flac", "c.txt", "d.wav"] {
+            std::fs::write(tmp.path().join(name), b"").expect("write");
+        }
+        let found = scan_folder(tmp.path());
+        assert_eq!(found.len(), 3, "should find mp3, flac, wav but not txt");
+    }
+}

--- a/crates/sonic-core/src/lib.rs
+++ b/crates/sonic-core/src/lib.rs
@@ -8,8 +8,8 @@ pub mod audio;
 pub mod error;
 
 pub use audio::{
-    AudioBuffer, AudioDecoder, AudioFormat, AudioFormatInfo, AudioFormatType, DEFAULT_BAND_COUNT,
-    MetadataExtractor, PlayerManager, PlayerStatus, SpectrumAnalyzer, SpectrumData,
-    SymphoniaDecoder, TrackMetadata,
+    AUDIO_EXTENSIONS, AudioBuffer, AudioDecoder, AudioFormat, AudioFormatInfo, AudioFormatType,
+    DEFAULT_BAND_COUNT, MetadataExtractor, PlayerManager, PlayerStatus, Playlist, RepeatMode,
+    SpectrumAnalyzer, SpectrumData, SymphoniaDecoder, TrackInfo, TrackMetadata, scan_folder,
 };
 pub use error::{AudioError, Error, Result};


### PR DESCRIPTION
## Summary

- **`Playlist` struct** (`crates/sonic-core/src/audio/playlist.rs`): ordered track list with shuffle (Fisher-Yates LCG, no external crate) and `RepeatMode` (None → One → All cycle)
- **`scan_folder()`**: recursively collects audio files by extension (mp3, flac, wav, ogg, m4a, aac)
- **`TrackInfo`**: minimal track record with path, title, artist, duration; built from path with metadata overlay
- **Playlist commands**: `AddTracks`, `AddFolder`, `NextTrack`, `PreviousTrack`, `SelectTrack`, `RemoveTrack`, `ClearPlaylist`, `ToggleShuffle`, `CycleRepeat`
- **Auto-start**: first `AddTracks`/`AddFolder` auto-plays track 0 when player is idle
- **Auto-advance**: `was_playing` flag in 100ms status loop detects natural track-end (sink drained) and calls `playlist.next()` → load next file
- **`PlaylistUpdated` event**: delivers `Vec<TrackSummary>`, `current_index`, `total_duration` to UI
- **Slint side**: `PlaylistTrack` struct in `common.slint`, `playlist-items: [PlaylistTrack]` in `UiState`, bound to `PlaylistView`; hardcoded demo data and `FolderBrowser` component removed
- **UI callbacks** fully wired: file/folder dialogs via `rfd`, next/prev/shuffle/repeat/select/remove/clear all send real commands
- `on_load_track_clicked` now opens a multi-select file dialog → `AddTracks`

## Test plan

- [x] Run `just test` — 35 tests pass
- [x] Run `just clippy` — clean
- [x] Open app, click 📁 folder button → select a music folder → tracks appear in playlist, first track starts playing
- [x] Click 🎵 files button → select multiple files → appended to playlist
- [x] Click a track in the playlist → jumps to that track and starts playing
- [x] ▶ Next / ⏮ Previous buttons navigate the playlist
- [x] × remove button removes a track; 🗑 clear empties playlist and stops playback
- [x] Shuffle button randomizes playback order; repeat button cycles None → One → All
- [x] Track-end auto-advance: let a short track finish → next track begins automatically
- [x] Collapse playlist panel (⮜ button) → shows compact track count + play dot

Closes #28